### PR TITLE
Centralize configuration settings

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,20 +1,12 @@
 import os
-from dotenv import load_dotenv
 import telebot
 from telebot import types
 from openai import OpenAI
 
-# --- Конфиг: импорт из settings с фолбэком на .env ---
-try:
-    from settings import TOKEN, FREE_LIMIT, PAY_BUTTON_URL
-except Exception:
-    load_dotenv()
-    TOKEN = os.getenv("BOT_TOKEN")
-    FREE_LIMIT = int(os.getenv("FREE_LIMIT", "10"))
-    PAY_BUTTON_URL = os.getenv("PAY_BUTTON_URL", "https://yookassa.ru/")
+# --- Конфиг: значения централизованы в settings.py ---
+from settings import TOKEN, FREE_LIMIT, PAY_BUTTON_URL
 
 # --- Ключи ---
-load_dotenv()
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 
 if not TOKEN:

--- a/settings.py
+++ b/settings.py
@@ -5,9 +5,10 @@ from dotenv import load_dotenv
 load_dotenv()
 
 # Configuration values used by bot.py
+# They can be overridden via environment variables or a .env file
 TOKEN = os.getenv("BOT_TOKEN")
-FREE_LIMIT = 10
-PAY_BUTTON_URL = "https://yookassa.ru/"
+FREE_LIMIT = int(os.getenv("FREE_LIMIT", "10"))
+PAY_BUTTON_URL = os.getenv("PAY_BUTTON_URL", "https://yookassa.ru/")
 
 # Ensure the bot token is provided
 if not TOKEN:


### PR DESCRIPTION
## Summary
- Centralize bot configuration variables in `settings.py` and read them from environment variables.
- Simplify `bot.py` to import configuration directly from `settings.py`.

## Testing
- `python -m py_compile bot.py settings.py`


------
https://chatgpt.com/codex/tasks/task_b_68b036537e148323aa5f81ce344fe974