### PR TITLE
refactor: centralize config and state

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,21 +1,12 @@
-import os
-import telebot
 from telebot import types
-from openai import OpenAI
 
 # --- Конфиг: значения централизованы в settings.py ---
-from settings import TOKEN, FREE_LIMIT, PAY_BUTTON_URL
+from settings import bot, client, FREE_LIMIT, PAY_BUTTON_URL
 
-# --- Ключи ---
-OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 
-if not TOKEN:
-    raise ValueError("BOT_TOKEN не найден (ни в settings, ни в .env).")
-if not OPENAI_API_KEY:
-    raise ValueError("OPENAI_API_KEY не найден в .env.")
-
-bot = telebot.TeleBot(TOKEN, parse_mode="HTML")
-client = OpenAI(api_key=OPENAI_API_KEY)
+# --- Хранилища состояния пользователей ---
+user_counters = {}
+user_moods = {}
 
 # --- Клавиатуры ---
 def main_menu():

--- a/settings.py
+++ b/settings.py
@@ -1,18 +1,39 @@
+"""Centralised configuration for the Telegram bot.
+
+This module loads required credentials from environment variables and
+instantiates the :class:`telebot.TeleBot` and OpenAI client instances used
+throughout the project.  Importing this module has side effects (creating the
+clients) which is acceptable here because both objects are effectively single
+tons for the application lifecycle.
+"""
+
 import os
+
 from dotenv import load_dotenv
+import telebot
+from openai import OpenAI
+
 
 # Load variables from .env
 load_dotenv()
 
+
 # Configuration values used by bot.py
 # They can be overridden via environment variables or a .env file
 TOKEN = os.getenv("BOT_TOKEN")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 FREE_LIMIT = int(os.getenv("FREE_LIMIT", "10"))
 PAY_BUTTON_URL = os.getenv("PAY_BUTTON_URL", "https://yookassa.ru/")
 
-# Ensure the bot token is provided
+# Ensure required credentials are provided
 if not TOKEN:
-    raise ValueError(
-        "❌ BOT_TOKEN не найден в .env — проверь файл .env в корне проекта"
-    )
+    raise ValueError("❌ BOT_TOKEN не найден в .env — проверь файл .env в корне проекта")
+if not OPENAI_API_KEY:
+    raise ValueError("❌ OPENAI_API_KEY не найден в .env")
+
+
+# Instantiate shared clients
+bot = telebot.TeleBot(TOKEN, parse_mode="HTML")
+client = OpenAI(api_key=OPENAI_API_KEY)
+
 


### PR DESCRIPTION
## Summary
- centralize environment config and client creation in `settings`
- simplify `bot.py` by reusing shared clients and tracking user state

## Testing
- `python3 bot.py` *(fails: ❌ BOT_TOKEN не найден в .env — проверь файл .env в корне проекта)*

------
https://chatgpt.com/codex/tasks/task_b_68b038a7e2ec8323a394769ebd479e23