### PR TITLE
docs: add sample env config and setup guide

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Sample environment configuration for GPS-Bot
+# Copy this file to .env and replace placeholder values with real tokens.
+BOT_TOKEN=123456:ABCDEF
+OPENAI_API_KEY=sk-your-openai-api-key
+FREE_LIMIT=10
+PAY_BUTTON_URL=https://example.com/pay

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# GPS-Bot
+
+Telegram bot "Vnutrenniy GPS" (Internal GPS) for mood tracking and quick mental help.
+
+## Setup
+
+1. Install requirements:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Copy `.env.example` to `.env` and set real values for:
+   - `BOT_TOKEN` – Telegram bot token
+   - `OPENAI_API_KEY` – OpenAI API key
+   - `FREE_LIMIT` – number of free interactions (default 10)
+   - `PAY_BUTTON_URL` – link to payment page
+3. Run the bot:
+   ```bash
+   python3 bot.py
+   ```


### PR DESCRIPTION
## Summary
- provide `.env.example` template with required configuration keys
- document setup steps in README

## Testing
- `python -m py_compile bot.py settings.py && echo OK`


------
https://chatgpt.com/codex/tasks/task_b_68b03a2839d08323a95998c27dac6429