### PR TITLE
Fix GPT response parsing and improve .env loading

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -51,7 +51,7 @@ def gpt_answer(user_text: str) -> str:
                 {"role": "user", "content": user_text}
             ]
         )
-        return response.choices[0].message["content"]
+        return response.choices[0].message.content
     except Exception as e:
         return f"⚠️ Ошибка при обращении к GPT: {e}"
 

--- a/settings.py
+++ b/settings.py
@@ -1,10 +1,11 @@
 import os
+from pathlib import Path
 from dotenv import load_dotenv
 import telebot
 from openai import OpenAI
 
-# Загружаем переменные из .env
-load_dotenv()
+# Загружаем переменные из .env рядом с файлом
+load_dotenv(Path(__file__).resolve().parent / ".env")
 
 TOKEN = os.getenv("BOT_TOKEN")
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
@@ -15,6 +16,7 @@ if not TOKEN:
     raise ValueError("❌ BOT_TOKEN не найден в .env")
 if not OPENAI_API_KEY:
     raise ValueError("❌ OPENAI_API_KEY не найден в .env")
+os.environ["OPENAI_API_KEY"] = OPENAI_API_KEY
 
 bot = telebot.TeleBot(TOKEN, parse_mode="HTML")
 client = OpenAI(api_key=OPENAI_API_KEY)


### PR DESCRIPTION
## Summary
- Fix `gpt_answer` to access message content via attribute to avoid `ChatCompletionMessage` errors
- Load `.env` from module directory and export `OPENAI_API_KEY` so API keys are always available

## Testing
- `python -m py_compile settings.py bot.py`


------
https://chatgpt.com/codex/tasks/task_b_68b6cb16b25c8323b2b81874d61a2ca6