### PR TITLE
Add short reply filtering helper

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -4,6 +4,17 @@ import re
 # --- Конфиг: значения централизованы в settings.py ---
 from settings import bot, client, FREE_LIMIT, PAY_BUTTON_URL, SYSTEM_PROMPT
 
+# --- Фильтр: оставляем только 1 утверждение + 1 вопрос ---
+def force_short_reply(text: str) -> str:
+    sentences = re.split(r'(?<=[.?!])\s+', text.strip())
+    short = []
+    for s in sentences:
+        if s:
+            short.append(s.strip())
+        if len(short) == 2:
+            break
+    return " ".join(short)
+
 # --- Хранилища состояния пользователей ---
 user_counters = {}
 user_moods = {}


### PR DESCRIPTION
## Summary
- Add `force_short_reply` utility limiting output to one statement and one question

## Testing
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_b_68b7e1596df48323b20a8160576000ef