### PR TITLE
feat: add owner exemption for usage limits

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -2,7 +2,7 @@ from telebot import types
 import re
 
 # --- Конфиг: значения централизованы в settings.py ---
-from settings import bot, client, FREE_LIMIT, PAY_BUTTON_URL
+from settings import bot, client, FREE_LIMIT, PAY_BUTTON_URL, OWNER_IDS
 
 # --- Фильтр: оставляем только 1 утверждение + 1 вопрос ---
 def force_short_reply(text: str) -> str:
@@ -35,6 +35,10 @@ def pay_inline():
 
 # --- Проверка лимита ---
 def check_limit(chat_id) -> bool:
+    # 🚀 Владельцу бота лимиты не применяются
+    if chat_id in OWNER_IDS:
+        return True
+
     used = user_counters.get(chat_id, 0)
     if used >= FREE_LIMIT:
         bot.send_message(

--- a/settings.py
+++ b/settings.py
@@ -37,3 +37,5 @@ __all__ = [
     "PAY_BUTTON_URL",
     "SYSTEM_PROMPT",
 ]
+
+OWNER_IDS = [1308643253]


### PR DESCRIPTION
## Summary
- add owner ID list to settings
- skip limit checks for owner account in bot

## Testing
- `python -m py_compile bot.py settings.py`


------
https://chatgpt.com/codex/tasks/task_b_68b927a874c48323b086b9064d5d00dc