### PR TITLE
Refactor: streamline bot menus

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -26,19 +26,18 @@ user_histories = {}  # {chat_id: [ {role: "user"/"assistant", content: "..."}, .
 
 # --- Клавиатуры ---
 def main_menu():
-    kb = types.ReplyKeyboardMarkup(resize_keyboard=True, row_width=2)
-    kb.add("Чек-ин настроения", "Быстрая помощь")
-    kb.add("Статистика", "Оплатить подписку")
+    kb = types.ReplyKeyboardMarkup(resize_keyboard=True, row_width=3)
+    kb.add("Чек-ин настроения", "Статистика", "Оплатить")
     return kb
 
-def pay_inline():
-    ikb = types.InlineKeyboardMarkup()
-    ikb.add(
-        types.InlineKeyboardButton("🌱 Созвучие — 299 ₽", url=PAY_URL_HARMONY),
-        types.InlineKeyboardButton("🌿 Отражение — 999 ₽", url=PAY_URL_REFLECTION),
-        types.InlineKeyboardButton("🌌 Путешествие — 1999 ₽", url=PAY_URL_TRAVEL),
-    )
-    return ikb
+
+def pay_menu():
+    kb = types.ReplyKeyboardMarkup(resize_keyboard=True, row_width=1)
+    kb.add("🌱 Созвучие — 299 ₽")
+    kb.add("🌿 Отражение — 999 ₽")
+    kb.add("🌌 Путешествие — 1999 ₽")
+    kb.add("⬅️ Назад")
+    return kb
 
 # --- Проверка лимита ---
 def check_limit(chat_id) -> bool:
@@ -52,7 +51,7 @@ def check_limit(chat_id) -> bool:
             chat_id,
             "🚫 <b>Лимит бесплатных диалогов исчерпан.</b>\n"
             "Выберите тариф 👇",
-            reply_markup=pay_inline(),
+            reply_markup=pay_menu(),
         )
         return False
     return True
@@ -115,13 +114,10 @@ def start(m):
     user_counters[m.chat.id] = 0
     user_moods[m.chat.id] = []
     text = (
-        "Привет 👋 Я твой <b>Внутренний GPS</b>.\n\n"
-        "• Бесплатно доступны <b>10 диалогов</b>\n"
-        "• Доступные тарифы:\n\n"
+        "<b>Внутренний GPS</b>\n"
+        "● online\n\n"
+        "Привет 👋 Я твой Внутренний GPS!"
     )
-    for key, t in TARIFFS.items():
-        text += f"{t['name']} — {t['price']} ₽/мес.\n"
-
     bot.send_message(m.chat.id, text, reply_markup=main_menu())
 
 @bot.message_handler(func=lambda msg: msg.text == "Чек-ин настроения")
@@ -140,19 +136,6 @@ def mood_save(m):
     user_moods.setdefault(m.chat.id, []).append(m.text)
     bot.send_message(m.chat.id, f"Принял {m.text}. Спасибо за отметку!", reply_markup=main_menu())
 
-@bot.message_handler(func=lambda msg: msg.text == "Быстрая помощь")
-def quick_help(m):
-    if not check_limit(m.chat.id): return
-    increment_counter(m.chat.id)
-    bot.send_message(
-        m.chat.id,
-        "🧭 <b>Быстрая помощь</b>\n"
-        "• Дыхание 4-7-8\n"
-        "• Техника «5 вещей вокруг»\n"
-        "• Мышечное расслабление\n",
-        reply_markup=main_menu()
-    )
-
 @bot.message_handler(func=lambda msg: msg.text == "Статистика")
 def stats(m):
     if not check_limit(m.chat.id): return
@@ -169,17 +152,48 @@ def stats(m):
         reply_markup=main_menu()
     )
 
-@bot.message_handler(func=lambda msg: msg.text == "Оплатить подписку")
+@bot.message_handler(func=lambda msg: msg.text == "Оплатить")
 def pay_button(m):
     bot.send_message(
         m.chat.id,
-        "Оплата подписки через ЮKassa. Выберите тариф 👇",
-        reply_markup=pay_inline()
+        "Выбери тариф 👇",
+        reply_markup=pay_menu()
     )
+
+
+@bot.message_handler(
+    func=lambda msg: msg.text in [
+        "🌱 Созвучие — 299 ₽",
+        "🌿 Отражение — 999 ₽",
+        "🌌 Путешествие — 1999 ₽",
+    ]
+)
+def tariffs(m):
+    if "Созвучие" in m.text:
+        url = PAY_URL_HARMONY
+    elif "Отражение" in m.text:
+        url = PAY_URL_REFLECTION
+    else:
+        url = PAY_URL_TRAVEL
+
+    kb = types.InlineKeyboardMarkup()
+    kb.add(types.InlineKeyboardButton("Перейти к оплате 💳", url=url))
+    kb.add(types.InlineKeyboardButton("⬅️ Назад", callback_data="back"))
+
+    bot.send_message(m.chat.id, f"Ты выбрал: {m.text}", reply_markup=kb)
 
 @bot.message_handler(func=lambda msg: msg.text == "⬅️ Назад")
 def back_to_menu(m):
     bot.send_message(m.chat.id, "Главное меню:", reply_markup=main_menu())
+
+
+@bot.callback_query_handler(func=lambda call: call.data == "back")
+def callback_back(call):
+    bot.send_message(
+        call.message.chat.id,
+        "Главное меню:",
+        reply_markup=main_menu()
+    )
 
 # --- Команда для показа тарифов ---
 @bot.message_handler(commands=["tariffs"])


### PR DESCRIPTION
## Summary
- Simplify main menu to three buttons and add tariff selector
- Add reply keyboard for tariff choices with inline payment links
- Improve start message and limit notifications

## Testing
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_b_68be69590f8c8323be1d7e8c1426c870