### PR TITLE
refactor: use centralized settings and clean exports

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,7 +1,8 @@
-from telebot import types
 import re
 import threading
 import time
+
+from telebot import types
 
 from tariffs import TARIFFS, activate_tariff, check_expiring_tariffs
 from hints import get_hint
@@ -16,6 +17,7 @@ from settings import (
     PAY_URL_HARMONY,
     PAY_URL_REFLECTION,
     PAY_URL_TRAVEL,
+    SYSTEM_PROMPT,
 )
 
 # --- Хранилища состояния пользователей ---
@@ -79,14 +81,7 @@ def gpt_answer(chat_id: int, user_text: str) -> str:
         user_histories[chat_id] = history
 
         messages = [
-            {
-                "role": "system",
-                "content": (
-                    "Ты — друг и собеседник. "
-                    "Отвечай только коротко: одно поддерживающее предложение и один вопрос. "
-                    "Запрещено писать списки, длинные объяснения, несколько вопросов сразу."
-                ),
-            },
+            {"role": "system", "content": SYSTEM_PROMPT},
             {
                 "role": "assistant",
                 "content": "Слышу, что тебе тяжело. Скажи, это больше похоже на усталость или на тревогу?",

--- a/settings.py
+++ b/settings.py
@@ -14,6 +14,9 @@ PAY_URL_HARMONY = os.getenv("PAY_URL_HARMONY", "https://yookassa.ru/")
 PAY_URL_REFLECTION = os.getenv("PAY_URL_REFLECTION", "https://yookassa.ru/")
 PAY_URL_TRAVEL = os.getenv("PAY_URL_TRAVEL", "https://yookassa.ru/")
 
+# IDs of bot owners that bypass usage limits
+OWNER_IDS = [1308643253]
+
 # System prompt for the GPT assistant
 SYSTEM_PROMPT = (
     "Ты — тёплый и внимательный собеседник. "
@@ -40,6 +43,5 @@ __all__ = [
     "PAY_URL_REFLECTION",
     "PAY_URL_TRAVEL",
     "SYSTEM_PROMPT",
+    "OWNER_IDS",
 ]
-
-OWNER_IDS = [1308643253]


### PR DESCRIPTION
## Summary
- reuse shared system prompt from settings in bot
- expose OWNER_IDS in settings and tidy import order

## Testing
- `python -m py_compile bot.py settings.py`


------
https://chatgpt.com/codex/tasks/task_b_68be6e6b4c708323bb16c771c3bb7452