### PR TITLE
Increase retained chat history to 15 messages

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -13,6 +13,7 @@ from settings import (
     bot,
     client,
     FREE_LIMIT,
+    HISTORY_LIMIT,
     OWNER_IDS,
     PAY_URL_HARMONY,
     PAY_URL_REFLECTION,
@@ -77,7 +78,7 @@ def gpt_answer(chat_id: int, user_text: str) -> str:
     try:
         history = user_histories.get(chat_id, [])
         history.append({"role": "user", "content": user_text})
-        history = history[-5:]
+        history = history[-HISTORY_LIMIT:]
         user_histories[chat_id] = history
 
         messages = [
@@ -97,7 +98,7 @@ def gpt_answer(chat_id: int, user_text: str) -> str:
         reply = force_short_reply(reply)  # обрезаем всё длиннее 2 предложений
 
         history.append({"role": "assistant", "content": reply})
-        user_histories[chat_id] = history[-5:]
+        user_histories[chat_id] = history[-HISTORY_LIMIT:]
 
         return reply
     except Exception as e:

--- a/settings.py
+++ b/settings.py
@@ -17,6 +17,9 @@ PAY_URL_TRAVEL = os.getenv("PAY_URL_TRAVEL", "https://yookassa.ru/")
 # IDs of bot owners that bypass usage limits
 OWNER_IDS = [1308643253]
 
+# Maximum number of conversation messages to retain per user
+HISTORY_LIMIT = 15
+
 # System prompt for the GPT assistant
 SYSTEM_PROMPT = (
     "Ты — тёплый и внимательный собеседник. "
@@ -44,4 +47,5 @@ __all__ = [
     "PAY_URL_TRAVEL",
     "SYSTEM_PROMPT",
     "OWNER_IDS",
+    "HISTORY_LIMIT",
 ]


### PR DESCRIPTION
## Summary
- Centralize chat history limit as `HISTORY_LIMIT` in `settings.py`
- Retain the last 15 messages per user when building GPT request history

## Testing
- `python -m py_compile settings.py bot.py`


------
https://chatgpt.com/codex/tasks/task_b_68c0eecd32048323afa15c22f2f2aff1