### PR TITLE
Initialize database on startup

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -2,11 +2,11 @@ import re
 import threading
 import time
 
+from storage import init_db, get_used_free, increment_used
 from telebot import types
 
 from tariffs import TARIFFS, activate_tariff, check_expiring_tariffs
 from hints import get_hint
-from storage import get_used_free, increment_used, init_db
 
 # --- Конфиг: значения централизованы в settings.py ---
 from settings import (
@@ -21,14 +21,14 @@ from settings import (
     SYSTEM_PROMPT,
 )
 
+# Initialize the SQLite storage before handling any requests
+init_db()
+
 # --- Хранилища состояния пользователей ---
 user_moods = {}
 # Хранилище истории сообщений пользователей
 user_histories = {}  # {chat_id: [ {role: "user"/"assistant", content: "..."}, ... ]}
 user_messages = {}  # {chat_id: [message_id, ...]}
-
-# Ensure the SQLite storage is ready
-init_db()
 
 
 def send_and_store(chat_id, text, **kwargs):


### PR DESCRIPTION
## Summary
- Import storage helpers in bot and initialize database immediately after imports to ensure persistence is ready.

## Testing
- `python -m py_compile bot.py storage.py`


------
https://chatgpt.com/codex/tasks/task_b_68c3c26b425c8323a7e44b06a74ef509