### PR TITLE
Add tariff-mode mapping

### DIFF
--- a/tariffs.py
+++ b/tariffs.py
@@ -34,6 +34,13 @@ TARIFFS = {
     },
 }
 
+# --- Привязка тарифов к режимам общения ---
+TARIFF_MODES = {
+    "sozvuchie": "short_friend",   # 299 ₽ — Короткий друг
+    "otrazhenie": "philosopher",  # 999 ₽ — Философ
+    "puteshestvie": "coach"        # 1999 ₽ — Коуч
+}
+
 def activate_tariff(chat_id: int, tariff_key: str):
     if tariff_key not in TARIFFS:
         return None, "❌ Неизвестный тариф"


### PR DESCRIPTION
## Summary
- map tariffs to conversation modes via `TARIFF_MODES`

## Testing
- `python -m py_compile tariffs.py`
- `for f in *.py; do python -m py_compile "$f"; done`


------
https://chatgpt.com/codex/tasks/task_b_68c3d428c2688323b12abffc41e81253