### PR TITLE
Add media limit tracking to SQLite storage

### DIFF
--- a/storage.py
+++ b/storage.py
@@ -35,3 +35,132 @@ def increment_used(chat_id: int):
     c.execute("UPDATE users SET used_free = used_free + 1 WHERE chat_id = ?", (chat_id,))
     conn.commit()
     conn.close()
+
+# ---- НИЖЕ ДОБАВИТЬ код для мультимедиа-лимитов ----
+import datetime
+
+def _month_key(d: datetime.date | None = None) -> str:
+    d = d or datetime.date.today()
+    return d.strftime("%Y-%m")  # например '2025-09'
+
+def init_media_tables():
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    # Текущий баланс лимитов на месяц (осталось)
+    c.execute("""
+    CREATE TABLE IF NOT EXISTS media_balance (
+        chat_id INTEGER,
+        month TEXT,
+        photos_left INT DEFAULT 0,
+        docs_left INT DEFAULT 0,
+        analysis_left INT DEFAULT 0,
+        PRIMARY KEY (chat_id, month)
+    )
+    """)
+    # Триальные разовые лимиты для неоформивших тариф
+    c.execute("""
+    CREATE TABLE IF NOT EXISTS media_trials (
+        chat_id INTEGER PRIMARY KEY,
+        photo_used INT DEFAULT 0,
+        doc_used INT DEFAULT 0,
+        analysis_used INT DEFAULT 0
+    )
+    """)
+    conn.commit()
+    conn.close()
+
+# вызывать при старте приложения
+init_media_tables()
+
+def get_media_balance(chat_id: int) -> dict:
+    """Вернёт текущий остаток лимитов за этот месяц (или пусто, если ещё не инициализировали)."""
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    mk = _month_key()
+    c.execute("SELECT photos_left, docs_left, analysis_left FROM media_balance WHERE chat_id=? AND month=?",
+              (chat_id, mk))
+    row = c.fetchone()
+    conn.close()
+    if not row:
+        return {"photos_left": None, "docs_left": None, "analysis_left": None}
+    return {"photos_left": row[0], "docs_left": row[1], "analysis_left": row[2]}
+
+def set_media_balance(chat_id: int, photos: int, docs: int, analysis: int):
+    """Жёстко выставить баланс на текущий месяц (используется при активации тарифа/первом обращении)."""
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    mk = _month_key()
+    c.execute("""INSERT INTO media_balance(chat_id, month, photos_left, docs_left, analysis_left)
+                 VALUES(?,?,?,?,?)
+                 ON CONFLICT(chat_id, month) DO UPDATE SET
+                 photos_left=excluded.photos_left,
+                 docs_left=excluded.docs_left,
+                 analysis_left=excluded.analysis_left
+                 """, (chat_id, mk, photos, docs, analysis))
+    conn.commit()
+    conn.close()
+
+def dec_media(chat_id: int, kind: str, amount: int = 1) -> bool:
+    """Пробует списать лимит (photos/docs/analysis). Возвращает True при успехе."""
+    assert kind in ("photos", "docs", "analysis")
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    mk = _month_key()
+    col = {"photos":"photos_left", "docs":"docs_left", "analysis":"analysis_left"}[kind]
+    # Прочитать текущий остаток
+    c.execute(f"SELECT {col} FROM media_balance WHERE chat_id=? AND month=?", (chat_id, mk))
+    row = c.fetchone()
+    if not row or row[0] is None:
+        conn.close()
+        return False
+    left = row[0]
+    if left < amount:
+        conn.close()
+        return False
+    # Списать
+    c.execute(f"UPDATE media_balance SET {col} = {col} - ? WHERE chat_id=? AND month=?", (amount, chat_id, mk))
+    conn.commit()
+    conn.close()
+    return True
+
+def add_package(chat_id: int, kind: str, amount: int):
+    """Добавить купленный пакет в остаток лимитов текущего месяца."""
+    assert kind in ("photos", "docs", "analysis")
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    mk = _month_key()
+    col = {"photos":"photos_left", "docs":"docs_left", "analysis":"analysis_left"}[kind]
+    # гарантируем строку
+    c.execute("""INSERT OR IGNORE INTO media_balance(chat_id, month, photos_left, docs_left, analysis_left)
+                 VALUES(?,?,0,0,0)""", (chat_id, mk))
+    c.execute(f"UPDATE media_balance SET {col} = {col} + ? WHERE chat_id=? AND month=?", (amount, chat_id, mk))
+    conn.commit()
+    conn.close()
+
+def get_or_init_month_balance(chat_id: int, defaults: dict):
+    """Если нет строки на месяц — создаём по дефолтам (из тарифа)."""
+    bal = get_media_balance(chat_id)
+    if bal["photos_left"] is None:
+        set_media_balance(chat_id, defaults.get("photos", 0), defaults.get("docs", 0), defaults.get("analysis", 0))
+        return get_media_balance(chat_id)
+    return bal
+
+# Триал (по 1 штуке без тарифа)
+def read_trials(chat_id: int) -> dict:
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute("SELECT photo_used, doc_used, analysis_used FROM media_trials WHERE chat_id=?", (chat_id,))
+    row = c.fetchone()
+    conn.close()
+    if not row:
+        return {"photo_used": 0, "doc_used": 0, "analysis_used": 0}
+    return {"photo_used": row[0], "doc_used": row[1], "analysis_used": row[2]}
+
+def mark_trial_used(chat_id: int, kind: str):
+    col = {"photos":"photo_used", "docs":"doc_used", "analysis":"analysis_used"}[kind]
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute("INSERT OR IGNORE INTO media_trials(chat_id) VALUES(?)", (chat_id,))
+    c.execute(f"UPDATE media_trials SET {col}=1 WHERE chat_id=?", (chat_id,))
+    conn.commit()
+    conn.close()


### PR DESCRIPTION
## Summary
- Introduce media_balance and media_trials tables to track user media limits and trial usage
- Provide helper functions to manage monthly balances, decrement usage, add packages, and mark trial consumption

## Testing
- `python -m py_compile storage.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68c69ce46ae48323a1bcb521668cf245