### PR TITLE
feat: bypass limits for bot owner

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -25,7 +25,7 @@ from settings import (
     client,
     FREE_LIMIT,
     HISTORY_LIMIT,
-    OWNER_IDS,
+    is_owner,
     PAY_URL_HARMONY,
     PAY_URL_REFLECTION,
     PAY_URL_TRAVEL,
@@ -81,7 +81,7 @@ def pay_inline():
 # --- Проверка лимита ---
 
 def check_limit(chat_id) -> bool:
-    if chat_id in OWNER_IDS:
+    if is_owner(chat_id):
         return True
     used = get_used_free(chat_id)
     if used >= FREE_LIMIT:

--- a/media.py
+++ b/media.py
@@ -7,7 +7,7 @@ from openai import OpenAI
 from settings import bot, client, TOKEN, IMAGE_MODEL, VISION_MODEL, \
     PAY_URL_PACK_PHOTO_50, PAY_URL_PACK_PHOTO_200, \
     PAY_URL_PACK_DOC_10, PAY_URL_PACK_DOC_30, \
-    PAY_URL_PACK_ANALYZE_20, PAY_URL_PACK_ANALYZE_100
+    PAY_URL_PACK_ANALYZE_20, PAY_URL_PACK_ANALYZE_100, is_owner
 from tariffs import TARIFFS, user_tariffs
 from storage import get_or_init_month_balance, dec_media, get_media_balance, \
                     read_trials, mark_trial_used, add_package
@@ -56,6 +56,8 @@ def ensure_month_balance(chat_id: int):
 
 # Мягкая проверка лимитов с учётом триала (по 1 штуке, если нет тарифа)
 def try_consume(chat_id: int, kind: str) -> bool:
+    if is_owner(chat_id):
+        return True
     # если есть активный тариф — работаем с месячным балансом
     if user_tariffs.get(chat_id):
         ensure_month_balance(chat_id)

--- a/settings.py
+++ b/settings.py
@@ -26,8 +26,12 @@ PAY_URL_PACK_DOC_30 = os.getenv("PAY_URL_PACK_DOC_30", "https://yookassa.ru/")
 PAY_URL_PACK_ANALYZE_20 = os.getenv("PAY_URL_PACK_ANALYZE_20", "https://yookassa.ru/")
 PAY_URL_PACK_ANALYZE_100 = os.getenv("PAY_URL_PACK_ANALYZE_100", "https://yookassa.ru/")
 
-# IDs of bot owners that bypass usage limits
-OWNER_IDS = [1308643253]
+# ID владельца бота (без ограничений)
+OWNER_ID = 1308643253
+
+
+def is_owner(user_id: int) -> bool:
+    return user_id == OWNER_ID
 
 # Maximum number of conversation messages to retain per user
 HISTORY_LIMIT = 15
@@ -58,7 +62,8 @@ __all__ = [
     "PAY_URL_REFLECTION",
     "PAY_URL_TRAVEL",
     "SYSTEM_PROMPT",
-    "OWNER_IDS",
+    "OWNER_ID",
+    "is_owner",
     "HISTORY_LIMIT",
 ]
 

--- a/storage.py
+++ b/storage.py
@@ -1,5 +1,7 @@
 import sqlite3
 
+from settings import is_owner
+
 # Имя файла базы (создастся автоматически при первом запуске)
 DB_PATH = "users.db"
 
@@ -102,6 +104,8 @@ def set_media_balance(chat_id: int, photos: int, docs: int, analysis: int):
 
 def dec_media(chat_id: int, kind: str, amount: int = 1) -> bool:
     """Пробует списать лимит (photos/docs/analysis). Возвращает True при успехе."""
+    if is_owner(chat_id):
+        return True
     assert kind in ("photos", "docs", "analysis")
     conn = sqlite3.connect(DB_PATH)
     c = conn.cursor()


### PR DESCRIPTION
## Summary
- add `OWNER_ID` constant and `is_owner` helper to settings
- skip limit checks for the owner in chat, media, and storage logic

## Testing
- `python -m py_compile settings.py bot.py media.py storage.py`


------
https://chatgpt.com/codex/tasks/task_b_68c6bee25b04832389b87b0b92730acd