### PR TITLE
Add slash command handlers for bot menus

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -15,12 +15,14 @@ from tariffs import (
     user_tariffs,
     activate_tariff,
     check_expiring_tariffs,
+    pay_inline,
 )
 from hints import get_hint
 from info import get_info_text, info_keyboard
 
 # Ensure media handlers are registered
 import media
+from media import multimedia_menu
 
 # --- Конфиг: значения централизованы в settings.py ---
 from settings import (
@@ -164,6 +166,60 @@ def ensure_verified(
     return False
 
 
+# --- Регистрируем кнопки в меню Telegram (будут видны в канале под строкой чата)
+bot.set_my_commands([
+    types.BotCommand("info", "Тарифы и возможности GPT-5"),
+    types.BotCommand("pay", "Оплата тарифов"),
+    types.BotCommand("media", "Мультимедиа"),
+    types.BotCommand("profile", "Профиль"),
+])
+
+
+# --- /info
+@bot.message_handler(commands=["info"])
+def cmd_info(m):
+    bot.send_message(
+        m.chat.id,
+        get_info_text(),
+        reply_markup=info_keyboard(),
+        parse_mode="HTML",
+    )
+
+
+# --- /pay
+@bot.message_handler(commands=["pay"])
+def cmd_pay(m):
+    if not ensure_verified(m.chat.id, m.from_user.id, force_check=True):
+        return
+
+    bot.send_message(
+        m.chat.id,
+        "Выберите тариф:",
+        reply_markup=pay_inline(),
+    )
+
+
+# --- /media
+@bot.message_handler(commands=["media"])
+def cmd_media(m):
+    bot.send_message(
+        m.chat.id,
+        "Доступные мультимедиа функции:",
+        reply_markup=multimedia_menu(),
+    )
+
+
+# --- /profile
+@bot.message_handler(commands=["profile"])
+def cmd_profile(m):
+    bot.send_message(
+        m.chat.id,
+        f"Ваш ID: {m.from_user.id}\n"
+        f"Имя: {m.from_user.first_name}\n"
+        "Подписка: FREE (по умолчанию)",
+    )
+
+
 def send_and_store(chat_id, text, **kwargs):
     msg = bot.send_message(chat_id, text, **kwargs)
     user_messages.setdefault(chat_id, []).append(msg.message_id)
@@ -195,16 +251,6 @@ def pay_menu():
     kb.add("🌿 Отражение — 999 ₽")
     kb.add("🌌 Путешествие — 1999 ₽")
     kb.add("⬅️ Назад")
-    return kb
-
-def pay_inline():
-    kb = types.InlineKeyboardMarkup(row_width=1)
-    for key, t in TARIFFS.items():
-        kb.add(
-            types.InlineKeyboardButton(
-                f"{t['name']} • {t['price']} ₽", url=t["pay_url"]
-            )
-        )
     return kb
 
 # --- Проверка лимита ---

--- a/tariffs.py
+++ b/tariffs.py
@@ -10,6 +10,7 @@ import datetime
 
 from rewards import give_smile, give_avatar, give_next_card
 from settings import PAY_URL_HARMONY, PAY_URL_REFLECTION, PAY_URL_TRAVEL
+from telebot import types
 
 
 # --- Storage for active subscriptions ---
@@ -54,6 +55,19 @@ TARIFF_MODES = {
     "otrazhenie": "philosopher",  # 999 ₽ — Философ
     "puteshestvie": "academic",   # 1999 ₽ — Академический
 }
+
+
+def pay_inline() -> types.InlineKeyboardMarkup:
+    """Build an inline keyboard with tariff payment buttons."""
+
+    keyboard = types.InlineKeyboardMarkup(row_width=1)
+    for tariff in TARIFFS.values():
+        keyboard.add(
+            types.InlineKeyboardButton(
+                f"{tariff['name']} • {tariff['price']} ₽", url=tariff["pay_url"]
+            )
+        )
+    return keyboard
 
 
 def activate_tariff(chat_id: int, tariff_key: str):


### PR DESCRIPTION
## Summary
- register Telegram slash commands for info, pay, media, and profile actions
- implement command handlers that surface info text, payment options, multimedia menu, and basic profile info
- move the reusable inline payment keyboard helper into `tariffs.py`

## Testing
- python -m compileall bot.py tariffs.py

------
https://chatgpt.com/codex/tasks/task_b_68d13e554f3c83238a4010a80181c225