### PR TITLE
Adjust message limit check to respect tariff status

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -5,7 +5,7 @@ import datetime
 from pathlib import Path
 from typing import Set
 
-from storage import init_db, get_used_free, increment_used
+from storage import init_db, get_user_usage, increment_used
 from telebot import types
 
 # Tariff configuration and state tracking
@@ -275,8 +275,8 @@ def check_limit(chat_id) -> bool:
     if not ensure_verified(chat_id, chat_id, force_check=True):
         return False
 
-    used = get_used_free(chat_id)
-    if used >= FREE_LIMIT:
+    used, has_tariff = get_user_usage(chat_id)
+    if has_tariff == 0 and used >= FREE_LIMIT:
         bot.send_message(
             chat_id,
             "🚫 <b>Лимит бесплатных диалогов исчерпан.</b>\nВыберите тариф 👇",

--- a/storage.py
+++ b/storage.py
@@ -24,14 +24,24 @@ def init_db():
     conn.commit()
     conn.close()
 
-# --- Получить, сколько бесплатных сообщений уже использовал пользователь ---
-def get_used_free(chat_id: int) -> int:
+# --- Получить информацию об использовании и тарифе пользователя ---
+def get_user_usage(chat_id: int) -> tuple[int, int]:
     conn = sqlite3.connect(DB_PATH)
     c = conn.cursor()
-    c.execute("SELECT used_free FROM users WHERE chat_id = ?", (chat_id,))
+    c.execute("SELECT used_free, has_tariff FROM users WHERE chat_id = ?", (chat_id,))
     row = c.fetchone()
     conn.close()
-    return row[0] if row else 0
+    if not row:
+        return 0, 0
+    used_free = row[0] if row[0] is not None else 0
+    has_tariff = row[1] if row[1] is not None else 0
+    return used_free, has_tariff
+
+
+# --- Получить, сколько бесплатных сообщений уже использовал пользователь ---
+def get_used_free(chat_id: int) -> int:
+    used_free, _ = get_user_usage(chat_id)
+    return used_free
 
 # --- Увеличить счётчик использованных сообщений ---
 def increment_used(chat_id: int):


### PR DESCRIPTION
## Summary
- add a storage helper that returns both used_free and has_tariff for a chat
- update the message limit check to ignore the free limit when a tariff is active

## Testing
- python -m compileall bot.py storage.py

------
https://chatgpt.com/codex/tasks/task_b_68d28d7292a08323b33ba9d48e4483ae