### PR TITLE
Add Redis-backed chat history storage

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 pyTelegramBotAPI
 openai
+redis
 python-dotenv
 
 reportlab


### PR DESCRIPTION
## Summary
- add Redis-powered chat history helpers with a local fallback in `storage.py`
- persist and reset chat histories through the bot, including weekly cleanup hooks
- include the `redis` package requirement for the new storage backend

## Testing
- python -m compileall storage.py bot.py

------
https://chatgpt.com/codex/tasks/task_b_68d402e2a7c883239ec6a5253e842884