### PR TITLE
Use Set type hint for smembers

### DIFF
--- a/storage.py
+++ b/storage.py
@@ -3,7 +3,7 @@ import sqlite3
 import threading
 import time
 from datetime import date
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Set
 
 try:
     import redis  # type: ignore
@@ -71,7 +71,7 @@ class InMemoryRedis:
         members.add(str(member))
         return int(len(members) > before)
 
-    def smembers(self, key: str) -> set[str]:
+    def smembers(self, key: str) -> Set[str]:
         return set(self._sets.get(key, set()))
 
     def srem(self, key: str, member: int) -> int:


### PR DESCRIPTION
## Summary
- import `Set` from typing
- update the `smembers` method signature to use `Set[str]`

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d4539aaae8832387f99137b5686c8e