### PR TITLE
Fix typing for smembers in storage

### DIFF
--- a/storage.py
+++ b/storage.py
@@ -34,7 +34,7 @@ class InMemoryRedis:
 
     def __init__(self) -> None:
         self._store: Dict[str, tuple[str, float | None]] = {}
-        self._sets: Dict[str, set[str]] = {}
+        self._sets: Dict[str, Set[str]] = {}
 
     def _purge_if_expired(self, key: str) -> None:
         value = self._store.get(key)


### PR DESCRIPTION
## Summary
- replace the in-memory Redis set annotation with typing.Set to avoid subscripted built-in usage on older Python versions

## Testing
- python -m compileall storage.py

------
https://chatgpt.com/codex/tasks/task_b_68d456cc20e883239b2dbd7a23d7cee2