### PR TITLE
Stream chat responses and add background workers

### DIFF
--- a/bot_utils.py
+++ b/bot_utils.py
@@ -2,6 +2,8 @@
 from tariffs import TARIFFS
 from telebot import types
 
+from settings import bot
+
 
 def offer_renew(bot, chat_id, tariff_key=None):
     text = (
@@ -17,3 +19,11 @@ def offer_renew(bot, chat_id, tariff_key=None):
             )
         )
     bot.send_message(chat_id, text, reply_markup=kb)
+
+
+def show_typing(chat_id: int) -> None:
+    """Показывает пользователю статус «печатает…» в чате Telegram."""
+    try:
+        bot.send_chat_action(chat_id, "typing")
+    except Exception:
+        pass

--- a/media.py
+++ b/media.py
@@ -4,8 +4,6 @@ from datetime import date, datetime
 
 import requests
 from telebot import types
-from openai import OpenAI
-
 from settings import (
     bot,
     client,
@@ -29,7 +27,7 @@ from storage import (
     mark_trial_used,
     add_package,
 )
-from media_utils import make_pdf, make_excel, make_pptx
+from worker_media import enqueue_media_task
 
 # Состояние простое: что от пользователя ждём далее
 user_media_state = {}   # {chat_id: {"mode": "photo_gen"/"photo_analyze"/"pdf"/"excel"/"pptx"}}
@@ -195,8 +193,8 @@ def media_text_router(m):
             bot.send_message(m.chat.id, out_of_limit_text("docs"), reply_markup=multimedia_buy_menu())
             user_media_state.pop(m.chat.id, None)
             return
-        pdf_bytes = make_pdf(m.text or "")
-        bot.send_document(m.chat.id, document=io.BytesIO(pdf_bytes), visible_file_name="document.pdf", caption="PDF готов ✅")
+        bot.send_message(m.chat.id, "📄 Готовлю PDF, пришлю файл чуть позже…")
+        enqueue_media_task(m.chat.id, "pdf", m.text or "")
         user_media_state.pop(m.chat.id, None)
         return
 
@@ -205,8 +203,8 @@ def media_text_router(m):
             bot.send_message(m.chat.id, out_of_limit_text("docs"), reply_markup=multimedia_buy_menu())
             user_media_state.pop(m.chat.id, None)
             return
-        xlsx_bytes = make_excel(m.text or "")
-        bot.send_document(m.chat.id, document=io.BytesIO(xlsx_bytes), visible_file_name="data.xlsx", caption="Excel готов ✅")
+        bot.send_message(m.chat.id, "📊 Формирую Excel, отправлю, как только соберу данные…")
+        enqueue_media_task(m.chat.id, "excel", m.text or "")
         user_media_state.pop(m.chat.id, None)
         return
 
@@ -215,8 +213,8 @@ def media_text_router(m):
             bot.send_message(m.chat.id, out_of_limit_text("docs"), reply_markup=multimedia_buy_menu())
             user_media_state.pop(m.chat.id, None)
             return
-        pptx_bytes = make_pptx(m.text or "")
-        bot.send_document(m.chat.id, document=io.BytesIO(pptx_bytes), visible_file_name="slides.pptx", caption="Презентация готова ✅")
+        bot.send_message(m.chat.id, "🖼️ Собираю презентацию, скоро пришлю готовый файл…")
+        enqueue_media_task(m.chat.id, "pptx", m.text or "")
         user_media_state.pop(m.chat.id, None)
         return
 

--- a/payments_polling.py
+++ b/payments_polling.py
@@ -45,36 +45,42 @@ def add_payment(chat_id: int, tariff_key: str, payment_id: str) -> None:
     conn.close()
 
 
-def check_payments_loop() -> None:
+def _fetch_waiting_payments() -> list[tuple[int, int, str, str]]:
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute(
+        "SELECT id, chat_id, tariff_key, payment_id FROM pending_payments WHERE status='waiting'"
+    )
+    rows = c.fetchall()
+    conn.close()
+    return rows
+
+
+def _mark_payment_activated(row_id: int) -> None:
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute("UPDATE pending_payments SET status='activated' WHERE id=?", (row_id,))
+    conn.commit()
+    conn.close()
+
+
+def check_payments(bot_instance=bot) -> None:
+    """Проверить ожидающие платежи и активировать тарифы."""
+    for row_id, chat_id, tariff_key, payment_id in _fetch_waiting_payments():
+        try:
+            payment = Payment.find_one(payment_id)
+            if payment.status == "succeeded":
+                _reward, message = activate_tariff(chat_id, tariff_key)
+                bot_instance.send_message(chat_id, message)
+                _mark_payment_activated(row_id)
+        except Exception as exc:  # noqa: BLE001
+            print("Ошибка при проверке платежа:", exc)
+
+
+def check_payments_loop(bot_instance=bot) -> None:
     while True:
         try:
-            conn = sqlite3.connect(DB_PATH)
-            c = conn.cursor()
-            c.execute(
-                "SELECT id, chat_id, tariff_key, payment_id FROM pending_payments WHERE status='waiting'"
-            )
-            rows = c.fetchall()
-            conn.close()
-
-            for row_id, chat_id, tariff_key, payment_id in rows:
-                try:
-                    payment = Payment.find_one(payment_id)
-                    if payment.status == "succeeded":
-                        # Активируем тариф
-                        _reward, message = activate_tariff(chat_id, tariff_key)
-                        bot.send_message(chat_id, message)
-
-                        # Обновляем статус
-                        conn = sqlite3.connect(DB_PATH)
-                        c = conn.cursor()
-                        c.execute(
-                            "UPDATE pending_payments SET status='activated' WHERE id=?",
-                            (row_id,),
-                        )
-                        conn.commit()
-                        conn.close()
-                except Exception as exc:  # noqa: BLE001
-                    print("Ошибка при проверке платежа:", exc)
+            check_payments(bot_instance)
         except Exception as exc:  # noqa: BLE001
             print("Ошибка в цикле проверки платежей:", exc)
 

--- a/settings.py
+++ b/settings.py
@@ -1,5 +1,7 @@
 import os
 from pathlib import Path
+
+import httpx
 from dotenv import load_dotenv
 import telebot
 from openai import OpenAI
@@ -49,12 +51,20 @@ if not OPENAI_API_KEY:
 os.environ["OPENAI_API_KEY"] = OPENAI_API_KEY
 
 bot = telebot.TeleBot(TOKEN, parse_mode="HTML")
-client = OpenAI(api_key=OPENAI_API_KEY)
+
+http_client = httpx.Client(
+    http2=True,
+    timeout=10.0,
+    limits=httpx.Limits(max_keepalive_connections=20, max_connections=100),
+)
+
+client = OpenAI(api_key=OPENAI_API_KEY, http_client=http_client)
 
 # Explicit re-exports for clearer "from settings import ..." usage
 __all__ = [
     "bot",
     "client",
+    "http_client",
     "FREE_LIMIT",
     "PAY_URL_HARMONY",
     "PAY_URL_REFLECTION",

--- a/worker_media.py
+++ b/worker_media.py
@@ -1,0 +1,75 @@
+"""Background worker for generating media files without blocking the bot."""
+
+from __future__ import annotations
+
+import io
+import multiprocessing as mp
+from multiprocessing.process import BaseProcess
+from typing import Any, Optional
+
+from settings import bot
+import media_utils
+
+_MEDIA_QUEUE: Optional[mp.Queue] = None
+_MEDIA_PROCESS: Optional[BaseProcess] = None
+
+
+def media_worker(task_queue: "mp.Queue") -> None:
+    """Worker loop that processes media generation tasks."""
+    while True:
+        chat_id, task_type, payload = task_queue.get()
+        try:
+            if task_type == "pdf":
+                pdf_bytes = media_utils.make_pdf(str(payload or ""))
+                bot.send_document(
+                    chat_id,
+                    io.BytesIO(pdf_bytes),
+                    visible_file_name="document.pdf",
+                    caption="PDF готов ✅",
+                )
+            elif task_type == "excel":
+                xlsx_bytes = media_utils.make_excel(str(payload or ""))
+                bot.send_document(
+                    chat_id,
+                    io.BytesIO(xlsx_bytes),
+                    visible_file_name="data.xlsx",
+                    caption="Excel готов ✅",
+                )
+            elif task_type == "pptx":
+                pptx_bytes = media_utils.make_pptx(str(payload or ""))
+                bot.send_document(
+                    chat_id,
+                    io.BytesIO(pptx_bytes),
+                    visible_file_name="slides.pptx",
+                    caption="Презентация готова ✅",
+                )
+            else:
+                bot.send_message(chat_id, f"⚠️ Неизвестная задача: {task_type}")
+        except Exception as exc:  # noqa: BLE001 - хотим поймать любые сбои
+            bot.send_message(chat_id, f"⚠️ Ошибка обработки медиа: {exc}")
+
+
+def _ensure_queue() -> "mp.Queue":
+    global _MEDIA_QUEUE
+    if _MEDIA_QUEUE is None:
+        _MEDIA_QUEUE = mp.Queue()
+    return _MEDIA_QUEUE
+
+
+def start_media_worker() -> "mp.Queue":
+    """Ensure that the media worker process is running and return its queue."""
+    global _MEDIA_PROCESS
+    queue = _ensure_queue()
+    if _MEDIA_PROCESS is None or not _MEDIA_PROCESS.is_alive():
+        _MEDIA_PROCESS = mp.Process(target=media_worker, args=(queue,), daemon=True)
+        _MEDIA_PROCESS.start()
+    return queue
+
+
+def enqueue_media_task(chat_id: int, task_type: str, payload: Any) -> None:
+    """Schedule a media generation task for asynchronous processing."""
+    queue = start_media_worker()
+    queue.put((chat_id, task_type, payload))
+
+
+__all__ = ["enqueue_media_task", "start_media_worker", "media_worker"]

--- a/worker_payments.py
+++ b/worker_payments.py
@@ -1,0 +1,35 @@
+"""Dedicated process for polling and processing payments."""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+import time
+
+from settings import bot
+import payments_polling
+
+_PAYMENTS_PROCESS: mp.Process | None = None
+
+
+def payments_worker() -> None:
+    """Background loop that periodically checks payment status."""
+    payments_polling.init_payments_db()
+    while True:
+        try:
+            payments_polling.check_payments(bot)
+        except Exception as exc:  # noqa: BLE001
+            print(f"[payments_worker] Ошибка: {exc}")
+        time.sleep(10)
+
+
+def start_payments_worker() -> None:
+    """Запускает отдельный процесс для проверки платежей (idempotent)."""
+    global _PAYMENTS_PROCESS
+    if _PAYMENTS_PROCESS is not None and _PAYMENTS_PROCESS.is_alive():
+        return
+    process = mp.Process(target=payments_worker, daemon=True)
+    process.start()
+    _PAYMENTS_PROCESS = process
+
+
+__all__ = ["payments_worker", "start_payments_worker"]


### PR DESCRIPTION
## Summary
- enable streaming GPT replies with typing indicator and wire it into fallback and test-mode handlers
- add multiprocessing workers for media generation and payment polling, updating media and payment modules to use them
- configure the OpenAI client with a shared httpx session and expose a helper for Telegram typing indicators

## Testing
- python -m compileall bot.py bot_utils.py media.py payments_polling.py settings.py worker_media.py worker_payments.py

------
https://chatgpt.com/codex/tasks/task_b_68d6ef8a33d88323b8547de3bdf7df1a