### PR TITLE
Increase OpenAI client timeout

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -54,7 +54,7 @@ bot = telebot.TeleBot(TOKEN, parse_mode="HTML")
 
 http_client = httpx.Client(
     http2=True,
-    timeout=10.0,
+    timeout=60.0,
     limits=httpx.Limits(max_keepalive_connections=20, max_connections=100),
 )
 


### PR DESCRIPTION
## Summary
- increase the OpenAI HTTP client timeout to 60 seconds so longer generations can finish

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68d7ea4da4708323b314d4754dbb000c