### PR TITLE
Simplify OpenAI client initialization

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -1,7 +1,6 @@
 import os
 from pathlib import Path
 
-import httpx
 from dotenv import load_dotenv
 import telebot
 from openai import OpenAI
@@ -52,19 +51,12 @@ os.environ["OPENAI_API_KEY"] = OPENAI_API_KEY
 
 bot = telebot.TeleBot(TOKEN, parse_mode="HTML")
 
-http_client = httpx.Client(
-    http2=True,
-    timeout=60.0,
-    limits=httpx.Limits(max_keepalive_connections=20, max_connections=100),
-)
-
-client = OpenAI(api_key=OPENAI_API_KEY, http_client=http_client)
+client = OpenAI(api_key=OPENAI_API_KEY)
 
 # Explicit re-exports for clearer "from settings import ..." usage
 __all__ = [
     "bot",
     "client",
-    "http_client",
     "FREE_LIMIT",
     "PAY_URL_HARMONY",
     "PAY_URL_REFLECTION",


### PR DESCRIPTION
## Summary
- remove the custom httpx client setup in `settings.py`
- initialize the OpenAI client directly with the API key

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68d81d17a598832383213d6607a5a9b8