### PR TITLE
Configure chat model via settings

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -40,6 +40,7 @@ from bot_utils import show_typing
 from settings import (
     bot,
     client,
+    CHAT_MODEL,
     FREE_LIMIT,
     is_owner,
     PAY_URL_HARMONY,
@@ -504,7 +505,7 @@ def stream_gpt_answer(chat_id: int, user_text: str, mode_key: str = "short_frien
         # Синхронный (нестриминговый) запрос к GPT
         try:
             resp = client.chat.completions.create(
-                model="gpt-5-mini",
+                model=CHAT_MODEL,
                 messages=messages,
                 stream=False,
                 max_completion_tokens=800  # длинные ответы умещаются без обрезки

--- a/settings.py
+++ b/settings.py
@@ -19,6 +19,9 @@ PAY_URL_TRAVEL = os.getenv("PAY_URL_TRAVEL", "https://yookassa.ru/")
 IMAGE_MODEL = os.getenv("IMAGE_MODEL", "gpt-image-1")     # генерация изображений
 VISION_MODEL = os.getenv("VISION_MODEL", "gpt-4o-mini")   # анализ изображений (vision)
 
+# --- Модель для основного чата (GPT-5 mini) ---
+CHAT_MODEL = os.getenv("CHAT_MODEL", "gpt-5-mini")
+
 # --- Урлы для докупки пакетов (можно оставить заглушки) ---
 PAY_URL_PACK_PHOTO_50 = os.getenv("PAY_URL_PACK_PHOTO_50", "https://yookassa.ru/")
 PAY_URL_PACK_PHOTO_200 = os.getenv("PAY_URL_PACK_PHOTO_200", "https://yookassa.ru/")
@@ -70,6 +73,7 @@ __all__ = [
 __all__ += [
     "IMAGE_MODEL",
     "VISION_MODEL",
+    "CHAT_MODEL",
     "PAY_URL_PACK_PHOTO_50",
     "PAY_URL_PACK_PHOTO_200",
     "PAY_URL_PACK_DOC_10",


### PR DESCRIPTION
## Summary
- add a configurable `CHAT_MODEL` constant to `settings.py`
- use the shared chat model when creating non-streaming chat completions

## Testing
- python -m compileall bot.py settings.py

------
https://chatgpt.com/codex/tasks/task_b_68d82219440483238cb143d245fb0243