### PR TITLE
Add __main__ entry points for worker scripts

### DIFF
--- a/worker_media.py
+++ b/worker_media.py
@@ -73,3 +73,8 @@ def enqueue_media_task(chat_id: int, task_type: str, payload: Any) -> None:
 
 
 __all__ = ["enqueue_media_task", "start_media_worker", "media_worker"]
+
+
+if __name__ == "__main__":
+    queue = mp.Queue()
+    media_worker(queue)

--- a/worker_payments.py
+++ b/worker_payments.py
@@ -33,3 +33,7 @@ def start_payments_worker() -> None:
 
 
 __all__ = ["payments_worker", "start_payments_worker"]
+
+
+if __name__ == "__main__":
+    payments_worker()


### PR DESCRIPTION
## Summary
- add explicit __main__ guards so the payment and media workers keep running when invoked directly
- ensure the media worker creates a queue before entering its processing loop

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68d82cb0b0ac8323999837aa7b79cf33