### PR TITLE
Increase chat history retention

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -42,6 +42,7 @@ from settings import (
     client,
     CHAT_MODEL,
     FREE_LIMIT,
+    HISTORY_LIMIT,
     is_owner,
     PAY_URL_HARMONY,
     PAY_URL_REFLECTION,
@@ -581,7 +582,7 @@ def stream_gpt_answer(chat_id: int, user_text: str, mode_key: str = "short_frien
 
         # Сохраняем ответ в историю
         short_history.append({"role": "assistant", "content": final_text})
-        user_histories[chat_id] = short_history[-6:]
+        user_histories[chat_id] = short_history[-HISTORY_LIMIT:]
 
     finally:
         with suppress(Exception):

--- a/settings.py
+++ b/settings.py
@@ -38,7 +38,7 @@ def is_owner(user_id: int) -> bool:
     return user_id == OWNER_ID
 
 # Maximum number of conversation messages to retain per user
-HISTORY_LIMIT = 15
+HISTORY_LIMIT = 700  # Храним переписку за неделю (~100 сообщений в день × 7 дней)
 
 # System prompt for the GPT assistant
 SYSTEM_PROMPT = (


### PR DESCRIPTION
## Summary
- raise the chat history limit to retain a week of conversation
- apply the configured history limit when caching assistant replies

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d83135e11c8323b31010c920549084