### PR TITLE
Persist chat history and adjust usage limits

### DIFF
--- a/storage.py
+++ b/storage.py
@@ -346,6 +346,20 @@ def increment_used(chat_id: int):
     conn.commit()
     conn.close()
 
+
+def reset_used_free(chat_id: int) -> None:
+    """Сбросить счётчик бесплатных сообщений пользователя."""
+
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute(
+        "INSERT OR IGNORE INTO users(chat_id, used_free, has_tariff) VALUES(?, 0, 0)",
+        (chat_id,),
+    )
+    c.execute("UPDATE users SET used_free = 0 WHERE chat_id = ?", (chat_id,))
+    conn.commit()
+    conn.close()
+
 # ---- НИЖЕ ДОБАВИТЬ код для мультимедиа-лимитов ----
 import datetime
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import sys
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+


### PR DESCRIPTION
## Summary
- load cached chat history from storage before responding and persist updates after every reply
- keep free-usage counters clear for owners and paying users and delay background history cleanup until the seventh run
- add pytest configuration helper so repository root is importable during tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d83e98205483239cb6e8d20bfedc19