### PR TITLE
Handle Responses API objects in OpenAI adapter

### DIFF
--- a/openai_adapter.py
+++ b/openai_adapter.py
@@ -45,6 +45,11 @@ def coerce_content_to_text(content: Any) -> str:
     if text_attr is not None:
         return coerce_content_to_text(text_attr)
 
+    for attr_name in ("content", "value"):
+        attr_value = getattr(content, attr_name, None)
+        if attr_value is not None and attr_value is not content:
+            return coerce_content_to_text(attr_value)
+
     if isinstance(content, list):
         parts = [coerce_content_to_text(item) for item in content]
         return "".join(parts)


### PR DESCRIPTION
## Summary
- add attribute-based fallbacks so Responses API objects are coerced to plain text
- cover coerce/extract helpers with dummy Responses API payloads in unit tests
- ensure call_chat_completion returns assistant text for Responses API clients

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d84fb1d2848323b22e9a0a0095cb7f