### PR TITLE
Fix chat completion token parameter usage

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -64,7 +64,7 @@ def ask_gpt(messages: list[dict], *, max_tokens: int | None = None) -> str:
     resp = client.chat.completions.create(
         model=CHAT_MODEL,
         messages=messages,
-        max_tokens=max_tokens,
+        max_completion_tokens=max_tokens,
     )
     # Извлекаем строго текст ассистента
     choice = resp.choices[0]

--- a/openai_adapter.py
+++ b/openai_adapter.py
@@ -239,7 +239,7 @@ def call_chat_completion(
     if chat_api and hasattr(chat_api, "create"):
         kwargs = {"model": model, "messages": list(messages)}
         if max_tokens is not None:
-            kwargs["max_tokens"] = max_tokens
+            kwargs["max_completion_tokens"] = max_tokens
         if stream is not None:
             kwargs["stream"] = stream
         try:


### PR DESCRIPTION
## Summary
- update the chat.completions call to use max_completion_tokens for GPT-5 models
- adjust the shared OpenAI adapter to forward max_completion_tokens instead of the deprecated parameter

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68da1ad09f148323adbb1532ca6155d5