### PR TITLE
Improve fallback completion handling

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -600,12 +600,17 @@ def stream_gpt_answer(chat_id: int, user_text: str, mode_key: str = "short_frien
         except Exception:
             _logger.exception("Stream call failed, fallback to non-stream")
 
-        # Если поток не вернул текст, делаем обычный вызов
+        # Если поток не вернул текст — делаем обычный вызов.
+        # Сначала пробуем с умеренным лимитом, затем при пустом результате увеличиваем лимит.
         if not final_text:
             try:
-                # Уменьшаем лимит генерируемых токенов для ускорения ответа
+                # Первая попытка: ограничиваем вывод 2048 токенами
                 final_text = ask_gpt(messages, max_tokens=2048)
                 final_text = (final_text or "").strip()
+                # Если ответ всё равно пустой — пробуем снова, но с большим лимитом
+                if not final_text:
+                    final_text = ask_gpt(messages, max_tokens=4096)
+                    final_text = (final_text or "").strip()
             except Exception:
                 final_text = ""
 


### PR DESCRIPTION
## Summary
- retry the non-streaming GPT call with a larger token limit when the initial attempt returns an empty response

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68da652929a483239ef7e7d3806fd0c2