### PR TITLE
Remove Telegram slash command menu

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -253,15 +253,6 @@ def ensure_verified(
     return False
 
 
-# --- Регистрируем кнопки в меню Telegram (будут видны в канале под строкой чата)
-bot.set_my_commands([
-    types.BotCommand("info", "Тарифы SynteraGPT"),
-    types.BotCommand("pay", "Оплата тарифов"),
-    types.BotCommand("media", "Мультимедиа"),
-    types.BotCommand("profile", "Профиль"),
-])
-
-
 # --- /info
 @bot.message_handler(commands=["info"])
 def cmd_info(m):


### PR DESCRIPTION
## Summary
- remove the registration of Telegram slash commands to disable the side menu

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68dd0b4801708323b86d4bf53c0a9fdb