### PR TITLE
Fix Telegram menu layout and hide slash commands

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -616,7 +616,15 @@ def stream_gpt_answer(chat_id: int, user_text: str, mode_key: str = "short_frien
 # --- Хэндлеры ---
 @bot.message_handler(commands=["start"])
 def start(m):
-    send_subscription_prompt(m.chat.id, m.from_user.id)
+    if ensure_verified(
+        m.chat.id,
+        m.from_user.id,
+        remind=False,
+        force_check=True,
+    ):
+        send_welcome_menu(m.chat.id)
+    else:
+        send_subscription_prompt(m.chat.id, m.from_user.id)
 
 
 @bot.message_handler(commands=["publish"])

--- a/settings.py
+++ b/settings.py
@@ -1,8 +1,11 @@
 import os
 from pathlib import Path
 
+from contextlib import suppress
+
 from dotenv import load_dotenv
 import telebot
+from telebot import types
 from openai import OpenAI
 
 # Загружаем переменные из .env рядом с файлом
@@ -53,6 +56,14 @@ if not OPENAI_API_KEY:
 os.environ["OPENAI_API_KEY"] = OPENAI_API_KEY
 
 bot = telebot.TeleBot(TOKEN, parse_mode="HTML")
+
+# По требованиям заказчика полностью убираем боковое меню со слеш-командами.
+# Для этого удаляем зарегистрированные команды и сбрасываем кнопку меню
+# (когда команд нет, Telegram больше не показывает боковую кнопку).
+with suppress(Exception):
+    bot.delete_my_commands()
+with suppress(Exception):
+    bot.set_chat_menu_button(menu_button=types.MenuButtonDefault())
 
 client = OpenAI(api_key=OPENAI_API_KEY)
 


### PR DESCRIPTION
## Summary
- remove the Telegram slash command sidebar by clearing the bot command list during startup
- show the reply keyboard when /start is used by verified users so the main menu buttons stay at the bottom

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68dd17d4cbdc8323bf6a8a18af0ef8f3