### PR TITLE
Ensure start menu displays main keyboard

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -308,12 +308,12 @@ def send_and_store(chat_id, text, **kwargs):
 
 def send_welcome_menu(chat_id: int) -> None:
     user_moods[chat_id] = []
-    text = (
-        "<b>SynteraGPT</b>\n"
-        "● online\n\n"
-        "Привет 👋 Я SynteraGPT — твой умный помощник!"
+    send_and_store(
+        chat_id,
+        START_CAPTION,
+        reply_markup=main_menu(),
+        parse_mode="HTML",
     )
-    send_and_store(chat_id, text, reply_markup=main_menu())
 
 # --- Клавиатуры ---
 


### PR DESCRIPTION
## Summary
- update the welcome menu helper to send the START_CAPTION copy with the reply keyboard
- ensure the start message is delivered with HTML formatting when presenting the main menu

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dd1e33548083239d3e691cb958fe80