### PR TITLE
Fix tariff activation and enforce billing env configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,14 @@ Telegram bot "SynteraGPT" for intelligent assistance with GPT-5, media analysis,
    pip install -r requirements.txt
    ```
 2. Copy `.env.example` to `.env` and set real values for:
-   - `BOT_TOKEN` – Telegram bot token
-   - `OPENAI_API_KEY` – OpenAI API key
+   - `BOT_TOKEN` – Telegram bot token (required)
+   - `OPENAI_API_KEY` – OpenAI API key (required)
    - `FREE_LIMIT` – number of free interactions (default 10)
-   - `PAY_URL_HARMONY` – payment link for the "Basic" tariff
-   - `PAY_URL_REFLECTION` – payment link for the "Pro" tariff
-   - `PAY_URL_TRAVEL` – payment link for the "Ultra" tariff
+   - `PAY_URL_HARMONY` – payment link for the "Basic" tariff (required)
+   - `PAY_URL_REFLECTION` – payment link for the "Pro" tariff (required)
+   - `PAY_URL_TRAVEL` – payment link for the "Ultra" tariff (required)
+   - `YOOKASSA_SHOP_ID` – YooKassa shop identifier used by the SDK (required)
+   - `YOOKASSA_API_KEY` – YooKassa secret key used by the SDK (required)
 3. Run the bot:
    ```bash
    python3 bot.py

--- a/bot.py
+++ b/bot.py
@@ -38,9 +38,6 @@ from info import get_info_text, info_keyboard
 import media
 from media import multimedia_menu
 
-# Register web handlers
-import handlers.web
-
 from bot_utils import show_typing
 from telebot import util as telebot_util
 

--- a/env.example
+++ b/env.example
@@ -6,3 +6,5 @@ FREE_LIMIT=10
 PAY_URL_HARMONY=https://example.com/harmony
 PAY_URL_REFLECTION=https://example.com/reflection
 PAY_URL_TRAVEL=https://example.com/travel
+YOOKASSA_SHOP_ID=123456
+YOOKASSA_API_KEY=live_your_yookassa_secret

--- a/media.py
+++ b/media.py
@@ -87,10 +87,17 @@ def ensure_month_balance(chat_id: int):
 def try_consume(chat_id: int, kind: str) -> bool:
     if is_owner(chat_id):
         return True
-    # если есть активный тариф → не проверяем лимиты
+    # если есть активный тариф — работаем с месячным балансом тарифа
     if _tariff_is_active(chat_id):
+        # списываем из месячного тарифа
+        info = user_tariffs.get(chat_id)
+        if info:
+            tariff = TARIFFS.get(info["tariff"])
+            if tariff:
+                ensure_month_balance(chat_id)
+                return dec_media(chat_id, kind, 1)
         return True
-    # если есть активный тариф — работаем с месячным балансом
+    # если тариф есть, но ещё не активирован (например, оплачивается) — подстрахуемся
     if user_tariffs.get(chat_id):
         ensure_month_balance(chat_id)
         return dec_media(chat_id, kind, 1)

--- a/settings.py
+++ b/settings.py
@@ -14,9 +14,9 @@ load_dotenv(Path(__file__).resolve().parent / ".env")
 TOKEN = os.getenv("BOT_TOKEN")
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 FREE_LIMIT = int(os.getenv("FREE_LIMIT", "10"))
-PAY_URL_HARMONY = os.getenv("PAY_URL_HARMONY", "https://yookassa.ru/")
-PAY_URL_REFLECTION = os.getenv("PAY_URL_REFLECTION", "https://yookassa.ru/")
-PAY_URL_TRAVEL = os.getenv("PAY_URL_TRAVEL", "https://yookassa.ru/")
+PAY_URL_HARMONY = os.getenv("PAY_URL_HARMONY")
+PAY_URL_REFLECTION = os.getenv("PAY_URL_REFLECTION")
+PAY_URL_TRAVEL = os.getenv("PAY_URL_TRAVEL")
 
 # --- Новые настройки моделей для мультимедиа ---
 IMAGE_MODEL = os.getenv("IMAGE_MODEL", "gpt-image-1")     # генерация изображений
@@ -53,6 +53,12 @@ if not TOKEN:
     raise ValueError("❌ BOT_TOKEN не найден в .env")
 if not OPENAI_API_KEY:
     raise ValueError("❌ OPENAI_API_KEY не найден в .env")
+if not PAY_URL_HARMONY:
+    raise ValueError("❌ PAY_URL_HARMONY не найден в .env")
+if not PAY_URL_REFLECTION:
+    raise ValueError("❌ PAY_URL_REFLECTION не найден в .env")
+if not PAY_URL_TRAVEL:
+    raise ValueError("❌ PAY_URL_TRAVEL не найден в .env")
 os.environ["OPENAI_API_KEY"] = OPENAI_API_KEY
 
 bot = telebot.TeleBot(TOKEN, parse_mode="HTML")
@@ -95,5 +101,10 @@ __all__ += [
 
 YOOKASSA_SHOP_ID = os.getenv("YOOKASSA_SHOP_ID")
 YOOKASSA_API_KEY = os.getenv("YOOKASSA_API_KEY")
+
+if not YOOKASSA_SHOP_ID:
+    raise ValueError("❌ YOOKASSA_SHOP_ID не найден в .env")
+if not YOOKASSA_API_KEY:
+    raise ValueError("❌ YOOKASSA_API_KEY не найден в .env")
 
 __all__ += ["YOOKASSA_SHOP_ID", "YOOKASSA_API_KEY"]

--- a/tariffs.py
+++ b/tariffs.py
@@ -21,7 +21,7 @@ from settings import (
     YOOKASSA_API_KEY,
     YOOKASSA_SHOP_ID,
 )
-from storage import DB_PATH
+from storage import DB_PATH, reset_used_free
 
 
 # --- Storage for active subscriptions ---
@@ -129,6 +129,7 @@ def activate_tariff(chat_id: int, tariff_key: str):
         (chat_id,),
     )
     c.execute("UPDATE users SET has_tariff=1 WHERE chat_id=?", (chat_id,))
+    reset_used_free(chat_id)  # сбрасываем счётчик бесплатных сообщений
     conn.commit()
     conn.close()
 


### PR DESCRIPTION
## Summary
- remove the stale handlers.web import so the bot starts without module errors
- reset free usage counters and properly charge media limits for active tariffs
- enforce required payment environment variables and update documentation/env example for YooKassa setup

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68dd3467fee883238d78184855f280e4