### PR TITLE
Ensure web search handlers are registered

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -38,6 +38,9 @@ from info import get_info_text, info_keyboard
 import media
 from media import multimedia_menu
 
+# Register web search handlers (command /web)
+import handlers.web  # noqa: F401 - регистрация хендлеров через импорт
+
 from bot_utils import show_typing
 from telebot import util as telebot_util
 


### PR DESCRIPTION
## Summary
- import the web handler module so that the /web command registers with TeleBot

## Testing
- not run (requires external services and bot credentials)


------
https://chatgpt.com/codex/tasks/task_b_68de6e25fc7083239153e5a12702db24