### PR TITLE
Handle empty GPT post text

### DIFF
--- a/auto_post.py
+++ b/auto_post.py
@@ -41,7 +41,17 @@ def _generate_post_text(mode: str = "long") -> str:
             response_format={"type": "text"},
             max_completion_tokens=400,
         )
-        return resp.choices[0].message.content.strip()
+
+        text = (
+            resp.choices[0].message.content
+            if resp.choices and resp.choices[0].message and resp.choices[0].message.content
+            else ""
+        )
+
+        if not text.strip():
+            raise ValueError("Empty GPT response")
+
+        return text.strip()
     except Exception as exc:
         print("[POSTGEN] Ошибка GPT:", exc)
         if mode == "short":


### PR DESCRIPTION
## Summary
- guard against empty responses when generating post captions
- fall back to the predefined caption when GPT returns no text

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e03828d3d88323b8c4ecbdcd657115