### PR TITLE
Remove free usage cap logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Telegram bot "SynteraGPT" for intelligent assistance with GPT-5, media analysis,
 2. Copy `.env.example` to `.env` and set real values for:
    - `BOT_TOKEN` – Telegram bot token (required)
    - `OPENAI_API_KEY` – OpenAI API key (required)
-   - `FREE_LIMIT` – number of free interactions (default 10)
    - `PAY_URL_HARMONY` – payment link for the "Basic" tariff (required)
    - `PAY_URL_REFLECTION` – payment link for the "Pro" tariff (required)
    - `PAY_URL_TRAVEL` – payment link for the "Ultra" tariff (required)

--- a/bot.py
+++ b/bot.py
@@ -10,12 +10,9 @@ from typing import Set
 
 from storage import (
     init_db,
-    get_user_usage,
-    increment_used,
     clear_history,
     iter_history_chat_ids,
     load_history,
-    reset_used_free,
     save_history,
     r,
     TTL,
@@ -49,7 +46,6 @@ from settings import (
     bot,
     client,
     CHAT_MODEL,
-    FREE_LIMIT,
     HISTORY_LIMIT,
     is_owner,
     PAY_URL_HARMONY,
@@ -387,33 +383,16 @@ def check_limit(chat_id) -> bool:
     if is_owner(chat_id):
         return True
 
-    if not ensure_verified(chat_id, chat_id, force_check=True):
-        return False
-
-    used, has_tariff = get_user_usage(chat_id)
-    if has_tariff == 0 and used >= FREE_LIMIT:
-        bot.send_message(
-            chat_id,
-            "🚫 <b>Лимит бесплатных диалогов исчерпан.</b>\nВыберите тариф 👇",
-            reply_markup=pay_inline(chat_id),
-        )
-        return False
-    return True
+    return ensure_verified(chat_id, chat_id, force_check=True)
 
 # --- Helpers ---
 
 def increment_counter(chat_id) -> None:
     if is_owner(chat_id):
-        reset_used_free(chat_id)
         return
 
-    used, has_tariff = get_user_usage(chat_id)
-    if has_tariff:
-        if used:
-            reset_used_free(chat_id)
-        return
-
-    increment_used(chat_id)
+    # Квоты отключены: счётчик сообщений больше не ведём для бесплатных пользователей.
+    return
 
 # --- Получение режима из активного тарифа ---
 

--- a/env.example
+++ b/env.example
@@ -2,7 +2,6 @@
 # Copy this file to .env and replace placeholder values with real tokens.
 BOT_TOKEN=7599608730:AAFOIL2zEFJU_AP6aX8...
 OPENAI_API_KEY=sk-your-openai-api-key
-FREE_LIMIT=10
 PAY_URL_HARMONY=https://example.com/harmony
 PAY_URL_REFLECTION=https://example.com/reflection
 PAY_URL_TRAVEL=https://example.com/travel

--- a/settings.py
+++ b/settings.py
@@ -13,7 +13,6 @@ load_dotenv(Path(__file__).resolve().parent / ".env")
 
 TOKEN = os.getenv("BOT_TOKEN")
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
-FREE_LIMIT = int(os.getenv("FREE_LIMIT", "10"))
 PAY_URL_HARMONY = os.getenv("PAY_URL_HARMONY")
 PAY_URL_REFLECTION = os.getenv("PAY_URL_REFLECTION")
 PAY_URL_TRAVEL = os.getenv("PAY_URL_TRAVEL")
@@ -77,7 +76,6 @@ client = OpenAI(api_key=OPENAI_API_KEY)
 __all__ = [
     "bot",
     "client",
-    "FREE_LIMIT",
     "PAY_URL_HARMONY",
     "PAY_URL_REFLECTION",
     "PAY_URL_TRAVEL",

--- a/tariffs.py
+++ b/tariffs.py
@@ -21,7 +21,7 @@ from settings import (
     YOOKASSA_API_KEY,
     YOOKASSA_SHOP_ID,
 )
-from storage import DB_PATH, reset_used_free
+from storage import DB_PATH
 
 
 # --- Storage for active subscriptions ---
@@ -129,7 +129,6 @@ def activate_tariff(chat_id: int, tariff_key: str):
         (chat_id,),
     )
     c.execute("UPDATE users SET has_tariff=1 WHERE chat_id=?", (chat_id,))
-    reset_used_free(chat_id)  # сбрасываем счётчик бесплатных сообщений
     conn.commit()
     conn.close()
 


### PR DESCRIPTION
## Summary
- remove the FREE_LIMIT setting and its documentation references
- simplify message limit checks to only ensure channel verification while leaving quotas disabled
- stop resetting free counters during tariff activation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e55b7f2ed8832387ba6745ef40f282