### PR TITLE
Limit SynteraGPT tariffs to the basic plan

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -53,8 +53,6 @@ from settings import (
     HISTORY_LIMIT,
     is_owner,
     PAY_URL_HARMONY,
-    PAY_URL_REFLECTION,
-    PAY_URL_TRAVEL,
     SYSTEM_PROMPT,
 )
 from openai_adapter import extract_response_text, prepare_responses_input
@@ -167,13 +165,14 @@ def subscription_check_keyboard() -> types.InlineKeyboardMarkup:
 
 def pay_inline(chat_id: int) -> types.InlineKeyboardMarkup:
     kb = types.InlineKeyboardMarkup(row_width=1)
-    for key, tariff in TARIFFS.items():
-        url = start_payment(chat_id, key)
-        kb.add(
-            types.InlineKeyboardButton(
-                f"{tariff['name']} • {tariff['price']} ₽", url=url
-            )
+    tariff_key = "basic"
+    tariff = TARIFFS[tariff_key]
+    url = start_payment(chat_id, tariff_key)
+    kb.add(
+        types.InlineKeyboardButton(
+            f"{tariff['name']} • {tariff['price']} ₽", url=url
         )
+    )
     return kb
 
 
@@ -331,8 +330,6 @@ def main_menu():
 def pay_menu():
     kb = types.ReplyKeyboardMarkup(resize_keyboard=True, row_width=1)
     kb.add("Basic • 299 ₽")
-    kb.add("Pro • 999 ₽")
-    kb.add("Ultra • 1999 ₽")
     kb.add("⬅️ Назад")
     return kb
 
@@ -754,23 +751,12 @@ def pay_button(m):
     )
 
 
-@bot.message_handler(
-    func=lambda msg: msg.text in [
-        "Basic • 299 ₽",
-        "Pro • 999 ₽",
-        "Ultra • 1999 ₽",
-    ]
-)
+@bot.message_handler(func=lambda msg: msg.text == "Basic • 299 ₽")
 def tariffs(m):
     if not ensure_verified(m.chat.id, m.from_user.id, force_check=True):
         return
 
-    if m.text.startswith("Basic"):
-        url = PAY_URL_HARMONY
-    elif m.text.startswith("Pro"):
-        url = PAY_URL_REFLECTION
-    else:
-        url = PAY_URL_TRAVEL
+    url = PAY_URL_HARMONY
 
     kb = types.InlineKeyboardMarkup()
     kb.add(types.InlineKeyboardButton("Перейти к оплате 💳", url=url))
@@ -819,17 +805,18 @@ def show_tariffs(m):
     if not ensure_verified(m.chat.id, m.from_user.id, force_check=True):
         return
 
-    text = "📜 <b>Выбери свой путь</b>\n\n"
-    for key, t in TARIFFS.items():
-        text += f"{t['name']} — {t['price']} ₽/мес.\n{t['description']}\n\n"
+    tariff = TARIFFS["basic"]
+    text = (
+        "📜 <b>SynteraGPT Basic</b>\n\n"
+        f"{tariff['name']} — {tariff['price']} ₽/мес.\n{tariff['description']}"
+    )
 
     kb = types.InlineKeyboardMarkup(row_width=1)
-    for key, t in TARIFFS.items():
-        kb.add(
-            types.InlineKeyboardButton(
-                f"{t['name']} • {t['price']} ₽", url=t["pay_url"]
-            )
+    kb.add(
+        types.InlineKeyboardButton(
+            f"{tariff['name']} • {tariff['price']} ₽", url=tariff["pay_url"]
         )
+    )
 
     send_and_store(m.chat.id, text, reply_markup=kb)
 
@@ -843,7 +830,7 @@ def activate(m):
     if len(parts) < 2:
         send_and_store(
             m.chat.id,
-            "❌ Укажи тариф: basic, pro или ultra",
+            "❌ Укажи тариф: basic",
         )
         return
 
@@ -865,7 +852,12 @@ def hint(m):
         return
 
     tariff_key, step = parts[1], int(parts[2])
-    hint_text = get_hint(TARIFFS[tariff_key]["category"], step)
+    tariff = TARIFFS.get(tariff_key)
+    if not tariff:
+        send_and_store(m.chat.id, "❌ Такой тариф недоступен")
+        return
+
+    hint_text = get_hint(tariff["category"], step)
     send_and_store(m.chat.id, f"🔮 Подсказка: {hint_text}")
 
 @bot.message_handler(

--- a/bot_utils.py
+++ b/bot_utils.py
@@ -11,13 +11,14 @@ def offer_renew(bot, chat_id, tariff_key=None):
         "Продолжай общение с SynteraGPT — впереди новые инструменты и открытия."
     )
     kb = types.InlineKeyboardMarkup(row_width=1)
-    for key, t in TARIFFS.items():
-        kb.add(
-            types.InlineKeyboardButton(
-                f"Продлить {t['name']} • {t['price']} ₽",
-                url=t["pay_url"],
-            )
+    tariff_name = tariff_key if tariff_key in TARIFFS else "basic"
+    tariff = TARIFFS[tariff_name]
+    kb.add(
+        types.InlineKeyboardButton(
+            f"Продлить {tariff['name']} • {tariff['price']} ₽",
+            url=tariff["pay_url"],
         )
+    )
     bot.send_message(chat_id, text, reply_markup=kb)
 
 

--- a/tariffs.py
+++ b/tariffs.py
@@ -7,20 +7,8 @@ import sqlite3
 
 from yookassa import Configuration, Payment
 
-from rewards import (
-    AVATAR_REWARDS,
-    BACKGROUND_REWARDS,
-    CARD_REWARDS,
-    ICON_REWARDS,
-    send_reward,
-)
-from settings import (
-    PAY_URL_HARMONY,
-    PAY_URL_REFLECTION,
-    PAY_URL_TRAVEL,
-    YOOKASSA_API_KEY,
-    YOOKASSA_SHOP_ID,
-)
+from rewards import ICON_REWARDS, send_reward
+from settings import PAY_URL_HARMONY, YOOKASSA_API_KEY, YOOKASSA_SHOP_ID
 from storage import DB_PATH, reset_used_free
 
 
@@ -38,27 +26,7 @@ TARIFFS = {
         "category": "basic",
         "pay_url": PAY_URL_HARMONY,
         "media_limits": {"photos": 1, "docs": 1, "analysis": 1},
-    },
-    "pro": {
-        "name": "Pro",
-        "price": 999,
-        "description": "SynteraGPT Pro — расширенные функции, мультимедиа и выход в интернет.",
-        "starter_reward": lambda chat_id: send_reward(chat_id, random.choice(AVATAR_REWARDS)),
-        "category": "pro",
-        "pay_url": PAY_URL_REFLECTION,
-        "media_limits": {"photos": 30, "docs": 10, "analysis": 20},
-    },
-    "ultra": {
-        "name": "Ultra",
-        "price": 1999,
-        "description": "SynteraGPT Ultra — полный доступ, максимум функций и расширенный интернет.",
-        "starter_reward": lambda chat_id: send_reward(
-            chat_id, random.choice(CARD_REWARDS + BACKGROUND_REWARDS)
-        ),
-        "category": "ultra",
-        "pay_url": PAY_URL_TRAVEL,
-        "media_limits": {"photos": 70, "docs": 20, "analysis": 30},
-    },
+    }
 }
 
 
@@ -70,8 +38,6 @@ Configuration.secret_key = YOOKASSA_API_KEY
 # --- Mapping tariffs to dialogue modes ---
 TARIFF_MODES = {
     "basic": "short_friend",  # 299₽ — короткие поддерживающие ответы
-    "pro": "philosopher",     # 999₽ — углублённые беседы
-    "ultra": "academic",      # 1999₽ — максимум аналитики
 }
 
 


### PR DESCRIPTION
## Summary
- collapse the tariff configuration to only include the Basic plan and trim dependent mappings
- simplify bot commands and menus so only the Basic subscription is offered or activated
- ensure renewal prompts highlight only the Basic plan

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e55b5abe6c8323927ddc5a206886c8