### PR TITLE
Add Redis CRM integration for basic tariff

### DIFF
--- a/env.example
+++ b/env.example
@@ -5,6 +5,13 @@ OPENAI_API_KEY=sk-your-openai-api-key
 PAY_URL_HARMONY=https://example.com/harmony
 PAY_URL_REFLECTION=https://example.com/reflection
 PAY_URL_TRAVEL=https://example.com/travel
+# Redis configuration (optional)
+REDIS_HOST=localhost
+REDIS_PORT=6379
+REDIS_DB=0
+# REDIS_PASSWORD=your-redis-password
+# CRM access code stored in Redis for active tariffs
+CRM_TARIFF_CODE=Syntera GPT 5
 # Дополнительные пакеты (опционально, но рекомендуется задать реальные ссылки)
 PAY_URL_PACK_PHOTO_50=https://example.com/packs/photo-50
 PAY_URL_PACK_PHOTO_200=https://example.com/packs/photo-200

--- a/storage.py
+++ b/storage.py
@@ -10,7 +10,15 @@ try:
 except ImportError:  # pragma: no cover - fallback for environments without redis
     redis = None
 
-from settings import OWNER_ID, bot, is_owner
+from settings import (
+    OWNER_ID,
+    REDIS_DB,
+    REDIS_HOST,
+    REDIS_PASSWORD,
+    REDIS_PORT,
+    bot,
+    is_owner,
+)
 
 TTL = 60 * 60 * 24 * 7  # 7 дней
 _REDIS_CHAT_SET_KEY = "chat:ids"
@@ -22,7 +30,15 @@ def _create_redis_client() -> "redis.Redis | None":
     if redis is None:
         return None
     try:
-        client = redis.Redis(host="localhost", port=6379, db=0, decode_responses=True)
+        connection_kwargs = {
+            "host": REDIS_HOST,
+            "port": REDIS_PORT,
+            "db": REDIS_DB,
+            "decode_responses": True,
+        }
+        if REDIS_PASSWORD:
+            connection_kwargs["password"] = REDIS_PASSWORD
+        client = redis.Redis(**connection_kwargs)
         client.ping()
         return client
     except redis.RedisError:


### PR DESCRIPTION
## Summary
- configure Redis connection details and CRM tariff code in settings and expose the shared client
- document Redis and CRM configuration variables in env.example and reuse them when creating Redis clients
- persist the CRM access code for the basic tariff in Redis during activation so CRM features can validate subscriptions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e56e1997c48323b74f4db13f002187