### PR TITLE
Add helper to read CRM tariff from Redis

### DIFF
--- a/tariffs.py
+++ b/tariffs.py
@@ -26,6 +26,7 @@ __all__ = [
     "start_payment",
     "activate_tariff",
     "check_expiring_tariffs",
+    "get_crm_access_code",
 ]
 
 
@@ -156,4 +157,24 @@ def _persist_crm_access(
     except Exception:
         # Redis is optional; ignore failures silently so activation succeeds.
         pass
+
+
+def get_crm_access_code(chat_id: int) -> Optional[str]:
+    """Return the CRM access code stored in Redis for the user, if available."""
+
+    if r is None:
+        return None
+
+    try:
+        value = r.get(f"user:{chat_id}:tariff")
+    except Exception:
+        return None
+
+    if value is None:
+        return None
+
+    if isinstance(value, bytes):
+        value = value.decode("utf-8")
+
+    return str(value)
 

--- a/tests/test_tariffs.py
+++ b/tests/test_tariffs.py
@@ -1,0 +1,53 @@
+"""Tests for tariff CRM helpers."""
+
+import os
+
+import pytest
+
+# Ensure required settings are present before importing the module under test.
+os.environ.setdefault("BOT_TOKEN", "123:ABC")
+os.environ.setdefault("OPENAI_API_KEY", "test")
+os.environ.setdefault("PAY_URL_HARMONY", "https://example.com")
+os.environ.setdefault("PAY_URL_REFLECTION", "https://example.com")
+os.environ.setdefault("PAY_URL_TRAVEL", "https://example.com")
+os.environ.setdefault("YOOKASSA_SHOP_ID", "1")
+os.environ.setdefault("YOOKASSA_API_KEY", "test")
+
+import tariffs
+
+
+class DummyRedis:
+    def __init__(self, value=None, should_raise=False):
+        self.value = value
+        self.should_raise = should_raise
+        self.called_with = None
+
+    def get(self, key):  # pragma: no cover - simple helper
+        if self.should_raise:
+            raise RuntimeError("redis error")
+        self.called_with = key
+        return self.value
+
+
+def test_get_crm_access_code_returns_none_without_redis(monkeypatch):
+    monkeypatch.setattr(tariffs, "r", None)
+    assert tariffs.get_crm_access_code(123) is None
+
+
+@pytest.mark.parametrize(
+    "stored, expected",
+    [("Syntera GPT 5", "Syntera GPT 5"), (b"Syntera GPT 5", "Syntera GPT 5")],
+)
+def test_get_crm_access_code_reads_value(monkeypatch, stored, expected):
+    dummy = DummyRedis(value=stored)
+    monkeypatch.setattr(tariffs, "r", dummy)
+
+    assert tariffs.get_crm_access_code(42) == expected
+    assert dummy.called_with == "user:42:tariff"
+
+
+def test_get_crm_access_code_handles_errors(monkeypatch):
+    dummy = DummyRedis(should_raise=True)
+    monkeypatch.setattr(tariffs, "r", dummy)
+
+    assert tariffs.get_crm_access_code(7) is None


### PR DESCRIPTION
## Summary
- expose a `get_crm_access_code` helper in `tariffs.py` to read the stored tariff CRM key from Redis
- add tests covering the helper behaviour with and without Redis access

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68e5723afac88323a6d7674997f23d2f