### PR TITLE
Add CRM button to main menu keyboard

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -279,9 +279,21 @@ def send_welcome_menu(chat_id: int) -> None:
 
 def main_menu():
     kb = types.ReplyKeyboardMarkup(resize_keyboard=True, row_width=3)
-    kb.add("Чек-ин", "Стата", "Оплата")
-    kb.add("Медиа", "Информация", "Профиль")
-    kb.add("Очистить", "Lang 🌐")
+    kb.add(
+        types.KeyboardButton("Чек-ин"),
+        types.KeyboardButton("Стата"),
+        types.KeyboardButton("Оплата"),
+    )
+    kb.add(
+        types.KeyboardButton("Медиа"),
+        types.KeyboardButton("Информация"),
+        types.KeyboardButton("Профиль"),
+    )
+    kb.add(
+        types.KeyboardButton("Очистить"),
+        types.KeyboardButton("Lang 🌐"),
+        types.KeyboardButton("СРМ"),
+    )
     return kb
 
 


### PR DESCRIPTION
## Summary
- keep existing main menu buttons as explicit KeyboardButton instances to ensure they remain visible
- add a new "СРМ" button to the main menu keyboard layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e57c9562a483238e71ead2ed10d8d0