### PR TITLE
Remove response_format argument from OpenAI calls

### DIFF
--- a/auto_post.py
+++ b/auto_post.py
@@ -38,7 +38,6 @@ def _generate_post_text(mode: str = "long") -> str:
         resp = openai_client.chat.completions.create(
             model=CHAT_MODEL,
             messages=[{"role": "user", "content": prompt}],
-            response_format={"type": "text"},
             max_completion_tokens=400,
         )
 

--- a/bot.py
+++ b/bot.py
@@ -490,7 +490,6 @@ def ask_gpt(
     kwargs: dict = {
         "model": CHAT_MODEL,
         "input": prepare_responses_input(messages),
-        "response_format": {"type": "text"},
         "stream": True,
     }
     if max_tokens is not None:

--- a/internet/__init__.py
+++ b/internet/__init__.py
@@ -29,7 +29,6 @@ def ask_gpt_web(query: str) -> str:
     response = client.responses.create(
         model=CHAT_MODEL,
         input=prepare_responses_input(messages),
-        response_format={"type": "text"},
         tools=[{"type": "web_search"}],
     )
     text = extract_response_text(response)


### PR DESCRIPTION
## Summary
- remove the response_format parameter from streaming calls to the Responses API
- stop passing response_format when generating auto posts with chat completions

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e58477ec408323aa6bd21f043bfb54