### PR TITLE
Fix foreign link replacement

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -73,7 +73,7 @@ def log_exception(exc: Exception) -> None:
 
 
 def replace_foreign_links_with_ru(text: str) -> str:
-    """Заменяет зарубежные ссылки на российские аналоги."""
+    """Заменяет зарубежные ссылки (weather.com, wikipedia.org и т.д.) на российские аналоги."""
     replacements = {
         r"https?://(www\.)?weather\.com[^\s)]*": "https://yandex.ru/pogoda",
         r"https?://(en\.)?wikipedia\.org[^\s)]*": "https://ru.wikipedia.org",
@@ -82,7 +82,7 @@ def replace_foreign_links_with_ru(text: str) -> str:
         r"https?://(www\.)?google\.com[^\s)]*": "https://yandex.ru",
     }
     for pattern, replacement in replacements.items():
-        text = re.sub(pattern, replacement, flags=re.IGNORECASE)
+        text = re.sub(pattern, replacement, text, flags=re.IGNORECASE)
     return text
 
 


### PR DESCRIPTION
## Summary
- update `replace_foreign_links_with_ru` to describe handled domains and pass the source text to `re.sub`

## Testing
- BOT_TOKEN=123456:ABC OPENAI_API_KEY=dummy python - <<'PY'
from bot import replace_foreign_links_with_ru

sample = "Check weather https://www.weather.com/some/path and wiki https://en.wikipedia.org/wiki/Test. Search google https://google.com. News https://cnn.com and BBC https://bbc.com"
print(replace_foreign_links_with_ru(sample))
PY

------
https://chatgpt.com/codex/tasks/task_b_68e7382a700083238cb8cd7661da0bd1