### PR TITLE
Clean Syntera bot command setup and auto posting

### DIFF
--- a/auto_post.py
+++ b/auto_post.py
@@ -1,341 +1,299 @@
-diff --git a/auto_post.py b/auto_post.py
-index 65d253e9060ec29eec7808ee3a82dbeab6303408..53a67416a9abfa70d1f325e5c46bc76eedbf52a0 100644
---- a/auto_post.py
-+++ b/auto_post.py
-@@ -1,165 +1,115 @@
--"""Автопостинг для каналов Syntera: разнообразные и актуальные публикации."""
-+"""Автопостинг контента для каналов Syntera."""
- 
- from __future__ import annotations
- 
- import base64
- import json
- import random
- import traceback
- from collections import deque
- from datetime import datetime
- from io import BytesIO
- from pathlib import Path
- from typing import Optional, Tuple
- 
-+from PIL import Image, UnidentifiedImageError
- from telebot import types
- 
- from openai_adapter import extract_response_text, prepare_responses_input
- from settings import OWNER_ID, bot, client as openai_client, CHAT_MODEL, IMAGE_MODEL
-- codex/restore-subscription-function-and-posts-qud580
--from PIL import Image, UnidentifiedImageError
--=======
-- main
- 
- CHANNEL_ID = "@SynteraAI"
- GROUP_ID = "@HubConsult"
- BOT_LINK = "https://t.me/SynteraGPT_bot"
- 
- SCENARIOS = [
-     "Расскажи мини-историю предпринимателя, который с помощью бота ускорил запуск продукта",
-     "Сфокусируйся на свежей истории успеха из мира искусственного интеллекта и свяжи её с возможностями SynteraGPT",
-     "Опиши, как команда аналитиков использует бота для глубоких исследований и подготовки отчётов",
-     "Представь, что пользователь ищет нестандартные идеи для контента и находит их через SynteraGPT",
-     "Сделай акцент на экспертной поддержке сообщества AI Systems и живом общении в Hubconsult",
-     "Покажи, как SynteraGPT помогает автоматизировать рутинные задачи специалиста по маркетингу",
-     "Опиши утро человека, который экономит время благодаря быстрым ответам и поиску с SynteraGPT",
- ]
- 
- DEFAULT_IMAGE_PROMPT = (
-     "Футуристичный баннер для Telegram-поста о SynteraGPT: неоновые акценты, технологии, "
-     "дружественная атмосфера, современный стиль."
- )
- FALLBACK_IMAGE = Path(__file__).resolve().parent / "syntera_logo.png"
- 
- _last_scenario: Optional[str] = None
- _recent_news_topics: deque[str] = deque(maxlen=12)
-- codex/restore-subscription-function-and-posts-qud580
--
--
--def _pick_scenario() -> str:
--    global _last_scenario
--
--    scenario = random.choice(SCENARIOS)
--    if _last_scenario and len(SCENARIOS) > 1:
--        attempts = 0
--        while scenario == _last_scenario and attempts < 5:
--            scenario = random.choice(SCENARIOS)
--            attempts += 1
--    _last_scenario = scenario
--    return scenario
--
--
--def _parse_json_payload(raw: str) -> Tuple[str, str]:
--    data = json.loads(raw)
--    post_text = (data.get("post") or "").strip()
--    image_prompt = (data.get("image_prompt") or "").strip()
--    if not post_text:
--        raise ValueError("Empty post text")
--    return post_text, image_prompt
--
--
--=======
- 
- 
- def _pick_scenario() -> str:
-     global _last_scenario
- 
-     scenario = random.choice(SCENARIOS)
-     if _last_scenario and len(SCENARIOS) > 1:
-         attempts = 0
-         while scenario == _last_scenario and attempts < 5:
-             scenario = random.choice(SCENARIOS)
-             attempts += 1
-     _last_scenario = scenario
-     return scenario
- 
- 
- def _parse_json_payload(raw: str) -> Tuple[str, str]:
-     data = json.loads(raw)
-     post_text = (data.get("post") or "").strip()
-     image_prompt = (data.get("image_prompt") or "").strip()
-     if not post_text:
-         raise ValueError("Empty post text")
-     return post_text, image_prompt
- 
- 
-- main
- def _generate_post_payload(mode: str) -> Tuple[str, str]:
-     scenario = _pick_scenario()
-     today = datetime.now().strftime("%d.%m.%Y")
-     length_instruction = {
-         "short": "Создай лаконичный, живой пост, который ощущается коротким — выбирай длину сам, но избегай однообразия.",
-         "long": "Создай развёрнутый пост с плавным развитием мысли. Делай его детальным и атмосферным без строгих ограничений по длине.",
-     }.get(mode, "Создай сбалансированный пост с богатой подачей и свободной длиной.")
-- codex/restore-subscription-function-and-posts-qud580
--
--    system_prompt = (
--        "Ты — креативный редактор Telegram-канала SynteraGPT. Каждый текст уникален, "
--        "играет с интонациями и подчеркивает выгоды бота. Вставляй максимум два эмодзи, если они усиливают подачу, "
--        "но не делай это обязательным."
--    )
--
--    user_prompt = (
--        f"Сегодня {today}. {length_instruction}\n"
--        f"Используй как вдохновение: {scenario}.\n"
--        "Расскажи, чем полезен SynteraGPT: доступ к интернету, анализ фото и документов, генерация кода, быстрые ответы.\n"
--        "Обязательно упомяни, что эксклюзивные материалы публикуются в канале AI Systems и в группе Hubconsult.\n"
--        f"Добавь естественный призыв перейти к боту по ссылке {BOT_LINK}.\n"
--        "Меняй структуру, чтобы каждый пост отличался от предыдущего.\n"
--        "Ответь строго в формате JSON с полями post и image_prompt."
--    )
--
--=======
- 
-     system_prompt = (
-         "Ты — креативный редактор Telegram-канала SynteraGPT. Каждый текст уникален, "
--        "играет с интонациями и подчеркивает выгоды бота. Вставляй максимум два эмодзи, если они усиливают подачу, "
-+        "играет с интонациями и подчёркивает выгоды бота. Вставляй максимум два эмодзи, если они усиливают подачу, "
-         "но не делай это обязательным."
-     )
- 
-     user_prompt = (
-         f"Сегодня {today}. {length_instruction}\n"
-         f"Используй как вдохновение: {scenario}.\n"
-         "Расскажи, чем полезен SynteraGPT: доступ к интернету, анализ фото и документов, генерация кода, быстрые ответы.\n"
-         "Обязательно упомяни, что эксклюзивные материалы публикуются в канале AI Systems и в группе Hubconsult.\n"
-         f"Добавь естественный призыв перейти к боту по ссылке {BOT_LINK}.\n"
-         "Меняй структуру, чтобы каждый пост отличался от предыдущего.\n"
-         "Ответь строго в формате JSON с полями post и image_prompt."
-     )
- 
-- main
-     try:
-         response = openai_client.chat.completions.create(
-             model=CHAT_MODEL,
-             messages=[
-                 {"role": "system", "content": system_prompt},
-                 {"role": "user", "content": user_prompt},
-             ],
-             max_completion_tokens=500,
-             temperature=0.85,
-             presence_penalty=0.4,
-             frequency_penalty=0.25,
-         )
-         content = response.choices[0].message.content if response.choices else ""
-         return _parse_json_payload(content)
-     except Exception as exc:  # noqa: BLE001
-         print("[POSTGEN] Ошибка генерации текста:", exc)
-         if mode == "short":
-             return (
-                 "SynteraGPT всегда под рукой, чтобы подсказать идею, подготовить текст или накидать код. "
-                 "Подписывайся на AI Systems, заглядывай в Hubconsult и загляни к боту, когда нужна помощь!",
-                 DEFAULT_IMAGE_PROMPT,
-             )
-         return (
-             (
-                 "SynteraGPT помогает решать задачи в пару кликов: ищет факты онлайн, анализирует документы, пишет код и держит в тонусе. "
-diff --git a/auto_post.py b/auto_post.py
-index 65d253e9060ec29eec7808ee3a82dbeab6303408..53a67416a9abfa70d1f325e5c46bc76eedbf52a0 100644
---- a/auto_post.py
-+++ b/auto_post.py
-@@ -176,156 +126,125 @@ def _generate_news_payload() -> Tuple[str, str, str]:
-         "Ты — редактор новостного канала SynteraGPT. Используй инструмент web_search, чтобы находить свежие новости "
-         "об искусственном интеллекте, технологиях и программировании по всему миру. Стремись выбирать темы, которых ещё не было."
-     )
-     user_prompt = (
-         f"Сегодня {today}. Найди актуальный материал об ИИ, технологиях или программировании. "
-         f"Избегай повторов тем: {avoided_topics}.\n"
-         "Если действительно свежих новостей нет, возьми важную публикацию последней недели и расскажи о ней как об уже состоявшемся событии с выводами.\n"
-         "Пост должен вдохновлять подписаться на AI Systems и вступить в Hubconsult, а также приглашать перейти к боту SynteraGPT.\n"
-         "Ответь в JSON с полями: post, image_prompt, headline."
-     )
- 
-     try:
-         response = openai_client.responses.create(
-             model=CHAT_MODEL,
-             input=prepare_responses_input(
-                 [
-                     {"role": "system", "content": system_prompt},
-                     {"role": "user", "content": user_prompt},
-                 ]
-             ),
-             tools=[{"type": "web_search"}],
-             response_format={"type": "json_object"},
-             max_output_tokens=650,
-             temperature=0.8,
-             presence_penalty=0.3,
-- codex/restore-subscription-function-and-posts-qud580
-+            frequency_penalty=0.2,
-         )
-         payload = extract_response_text(response)
-         text, image_prompt = _parse_json_payload(payload)
-         data = json.loads(payload)
-         headline = (data.get("headline") or text[:80]).strip()
-         if headline:
-             _recent_news_topics.append(headline.lower())
-         return text, image_prompt, headline
-     except Exception as exc:  # noqa: BLE001
-         print("[POSTGEN] Ошибка генерации новостного поста:", exc)
-         return (
-             "Сегодня мы разобрали заметную новость из мира ИИ: компании по всему миру внедряют умных ассистентов, "
-             "а SynteraGPT помогает опробовать такие решения бесплатно. Подписывайтесь на AI Systems, обсуждайте свежие кейсы в Hubconsult и жмите на бота!",
-             DEFAULT_IMAGE_PROMPT,
-             "fallback",
-         )
- 
- 
- def _normalize_image(image_bytes: bytes) -> Optional[bytes]:
-     try:
-         with Image.open(BytesIO(image_bytes)) as img:
-             if img.mode not in {"RGB", "L"}:
-                 img = img.convert("RGB")
-             elif img.mode != "RGB":
-                 img = img.convert("RGB")
- 
-             buffer = BytesIO()
-             img.save(buffer, format="JPEG", quality=90, optimize=True)
-             return buffer.getvalue()
-     except (UnidentifiedImageError, OSError):
-         return None
--=======
--        )
--        payload = extract_response_text(response)
--        text, image_prompt = _parse_json_payload(payload)
--        data = json.loads(payload)
--        headline = (data.get("headline") or text[:80]).strip()
--        if headline:
--            _recent_news_topics.append(headline.lower())
--        return text, image_prompt, headline
--    except Exception as exc:  # noqa: BLE001
--        print("[POSTGEN] Ошибка генерации новостного поста:", exc)
--        return (
--            "Сегодня мы разобрали заметную новость из мира ИИ: компании по всему миру внедряют умных ассистентов, "
--            "а SynteraGPT помогает опробовать такие решения бесплатно. Подписывайтесь на AI Systems, обсуждайте свежие кейсы в Hubconsult и жмите на бота!",
--            DEFAULT_IMAGE_PROMPT,
--            "fallback",
--        )
-- main
- 
- 
- def _generate_image_bytes(image_prompt: str) -> Optional[bytes]:
-     prompt = image_prompt or DEFAULT_IMAGE_PROMPT
-- codex/restore-subscription-function-and-posts-qud580
-     raw_bytes: Optional[bytes] = None
--=======
-- main
-+
-     try:
-         result = openai_client.images.generate(
-             model=IMAGE_MODEL,
-             prompt=prompt,
-             size="1792x1024",
-             quality="standard",
-         )
-         b64 = result.data[0].b64_json
-- codex/restore-subscription-function-and-posts-qud580
-         raw_bytes = base64.b64decode(b64)
-     except Exception as exc:  # noqa: BLE001
-         print("[POSTGEN] Ошибка генерации картинки:", exc)
-+
-     if raw_bytes:
-         normalized = _normalize_image(raw_bytes)
-         if normalized:
-             return normalized
-+
-     try:
-         with FALLBACK_IMAGE.open("rb") as backup:
--            raw_bytes = backup.read()
--            return _normalize_image(raw_bytes)
-+            fallback_bytes = backup.read()
-     except FileNotFoundError:
-         return None
--=======
--        return base64.b64decode(b64)
--    except Exception as exc:  # noqa: BLE001
--        print("[POSTGEN] Ошибка генерации картинки:", exc)
--        try:
--            with FALLBACK_IMAGE.open("rb") as backup:
--                return backup.read()
--        except FileNotFoundError:
--            return None
-- main
-+
-+    return _normalize_image(fallback_bytes) or fallback_bytes
- 
- 
- def _publish_post(message, caption: str, image_bytes: Optional[bytes]) -> None:
-     kb = types.InlineKeyboardMarkup()
-     kb.add(types.InlineKeyboardButton("Перейти к боту", url=BOT_LINK))
- 
-     targets = [CHANNEL_ID, GROUP_ID]
-     try:
-         for target in targets:
-             if image_bytes:
-                 buffer = BytesIO(image_bytes)
-                 buffer.name = "syntera_post.jpg"
-- codex/restore-subscription-function-and-posts-qud580
-                 buffer.seek(0)
--=======
-- main
-                 bot.send_photo(
-                     target,
-                     buffer,
-                     caption=caption,
-                     parse_mode="HTML",
-                     reply_markup=kb,
-                 )
-             else:
-                 bot.send_message(
-                     target,
-                     caption,
-                     parse_mode="HTML",
-                     reply_markup=kb,
-                 )
-         bot.reply_to(message, "✅ Пост опубликован в канал и группу.")
-     except Exception as exc:  # noqa: BLE001
-         bot.reply_to(message, f"❌ Ошибка при публикации: {exc}")
-         traceback.print_exc()
- 
- 
- def _handle_post_request(message, mode: str) -> None:
-     user_id = getattr(message.from_user, "id", None)
-     if user_id != OWNER_ID:
-         bot.reply_to(message, "⛔ Команда доступна только владельцу.")
-         return
+"""Автопостинг контента для каналов Syntera."""
+
+from __future__ import annotations
+
+import base64
+import json
+import random
+import traceback
+from collections import deque
+from contextlib import suppress
+from datetime import datetime
+from io import BytesIO
+from pathlib import Path
+from typing import Optional, Tuple
+
+from PIL import Image, UnidentifiedImageError
+from telebot import types
+
+from openai_adapter import extract_response_text, prepare_responses_input
+from settings import (
+    CHAT_MODEL,
+    IMAGE_MODEL,
+    OWNER_ID,
+    bot,
+    client as openai_client,
+)
+
+CHANNEL_ID = "@SynteraAI"
+GROUP_ID = "@HubConsult"
+BOT_LINK = "https://t.me/SynteraGPT_bot"
+
+SCENARIOS = [
+    "Расскажи мини-историю предпринимателя, который с помощью бота ускорил запуск продукта",
+    "Сфокусируйся на свежей истории успеха из мира искусственного интеллекта и свяжи её с возможностями SynteraGPT",
+    "Опиши, как команда аналитиков использует бота для глубоких исследований и подготовки отчётов",
+    "Представь, что пользователь ищет нестандартные идеи для контента и находит их через SynteraGPT",
+    "Сделай акцент на экспертной поддержке сообщества AI Systems и живом общении в Hubconsult",
+    "Покажи, как SynteraGPT помогает автоматизировать рутинные задачи специалиста по маркетингу",
+    "Опиши утро человека, который экономит время благодаря быстрым ответам и поиску с SynteraGPT",
+]
+
+DEFAULT_IMAGE_PROMPT = (
+    "Футуристичный баннер для Telegram-поста о SynteraGPT: неоновые акценты, технологии, "
+    "дружественная атмосфера, современный стиль."
+)
+FALLBACK_IMAGE = Path(__file__).resolve().parent / "syntera_logo.png"
+
+_last_scenario: Optional[str] = None
+_recent_news_topics: deque[str] = deque(maxlen=12)
+
+
+def _pick_scenario() -> str:
+    global _last_scenario
+
+    scenario = random.choice(SCENARIOS)
+    if _last_scenario and len(SCENARIOS) > 1:
+        attempts = 0
+        while scenario == _last_scenario and attempts < 5:
+            scenario = random.choice(SCENARIOS)
+            attempts += 1
+    _last_scenario = scenario
+    return scenario
+
+
+def _parse_json_payload(raw: str) -> Tuple[str, str]:
+    data = json.loads(raw)
+    post_text = (data.get("post") or "").strip()
+    image_prompt = (data.get("image_prompt") or "").strip()
+    if not post_text:
+        raise ValueError("Empty post text")
+    return post_text, image_prompt
+
+
+def _generate_post_payload(mode: str) -> Tuple[str, str]:
+    scenario = _pick_scenario()
+    today = datetime.now().strftime("%d.%m.%Y")
+    length_instruction = {
+        "short": "Создай лаконичный, живой пост, который ощущается коротким — выбирай длину сам, но избегай однообразия.",
+        "long": "Создай развёрнутый пост с плавным развитием мысли. Делай его детальным и атмосферным без строгих ограничений по длине.",
+    }.get(mode, "Создай сбалансированный пост с богатой подачей и свободной длиной.")
+
+    system_prompt = (
+        "Ты — креативный редактор Telegram-канала SynteraGPT. Каждый текст уникален, "
+        "играет с интонациями и подчёркивает выгоды бота. Вставляй максимум два эмодзи, если они усиливают подачу, "
+        "но не делай это обязательным."
+    )
+
+    user_prompt = (
+        f"Сегодня {today}. {length_instruction}\n"
+        f"Используй как вдохновение: {scenario}.\n"
+        "Расскажи, чем полезен SynteraGPT: доступ к интернету, анализ фото и документов, генерация кода, быстрые ответы.\n"
+        "Обязательно упомяни, что эксклюзивные материалы публикуются в канале AI Systems и в группе Hubconsult.\n"
+        f"Добавь естественный призыв перейти к боту по ссылке {BOT_LINK}.\n"
+        "Меняй структуру, чтобы каждый пост отличался от предыдущего.\n"
+        "Ответь строго в формате JSON с полями post и image_prompt."
+    )
+
+    try:
+        response = openai_client.chat.completions.create(
+            model=CHAT_MODEL,
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
+            ],
+            max_completion_tokens=500,
+            temperature=0.85,
+            presence_penalty=0.4,
+            frequency_penalty=0.25,
+        )
+        payload = extract_response_text(response)
+        return _parse_json_payload(payload)
+    except Exception as exc:  # noqa: BLE001
+        print("[POSTGEN] Ошибка генерации текста:", exc)
+        if mode == "short":
+            return (
+                "SynteraGPT всегда под рукой, чтобы подсказать идею, подготовить текст или накидать код. "
+                "Подписывайся на AI Systems, заглядывай в Hubconsult и заходи к боту, когда нужна помощь!",
+                DEFAULT_IMAGE_PROMPT,
+            )
+        return (
+            (
+                "SynteraGPT помогает решать задачи в пару кликов: ищет факты онлайн, анализирует документы, пишет код и держит в тонусе. "
+                "Подписывайся на канал AI Systems, обсуждай свежие кейсы в Hubconsult и переходи к боту SynteraGPT прямо сейчас!"
+            ),
+            DEFAULT_IMAGE_PROMPT,
+        )
+
+
+def _generate_news_payload() -> Tuple[str, str, str]:
+    today = datetime.now().strftime("%d.%m.%Y")
+    avoided_topics = ", ".join(_recent_news_topics) or "прошлые темы"
+
+    system_prompt = (
+        "Ты — редактор новостного канала SynteraGPT. Используй инструмент web_search, чтобы находить свежие новости "
+        "об искусственном интеллекте, технологиях и программировании по всему миру. Стремись выбирать темы, которых ещё не было."
+    )
+    user_prompt = (
+        f"Сегодня {today}. Найди актуальный материал об ИИ, технологиях или программировании. "
+        f"Избегай повторов тем: {avoided_topics}.\n"
+        "Если действительно свежих новостей нет, возьми важную публикацию последней недели и расскажи о ней как об уже состоявшемся событии с выводами.\n"
+        "Пост должен вдохновлять подписаться на AI Systems и вступить в Hubconsult, а также приглашать перейти к боту SynteraGPT.\n"
+        "Ответь в JSON с полями: post, image_prompt, headline."
+    )
+
+    try:
+        response = openai_client.responses.create(
+            model=CHAT_MODEL,
+            input=prepare_responses_input(
+                [
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_prompt},
+                ]
+            ),
+            tools=[{"type": "web_search"}],
+            response_format={"type": "json_object"},
+            max_output_tokens=650,
+            temperature=0.8,
+            presence_penalty=0.3,
+            frequency_penalty=0.2,
+        )
+        payload = extract_response_text(response)
+        text, image_prompt = _parse_json_payload(payload)
+        data = json.loads(payload)
+        headline = (data.get("headline") or text[:80]).strip()
+        if headline:
+            _recent_news_topics.append(headline.lower())
+        return text, image_prompt, headline
+    except Exception as exc:  # noqa: BLE001
+        print("[POSTGEN] Ошибка генерации новостного поста:", exc)
+        return (
+            "Сегодня мы разобрали заметную новость из мира ИИ: компании по всему миру внедряют умных ассистентов, "
+            "а SynteraGPT помогает опробовать такие решения бесплатно. Подписывайтесь на AI Systems, обсуждайте свежие кейсы в Hubconsult и жмите на бота!",
+            DEFAULT_IMAGE_PROMPT,
+            "",
+        )
+
+
+def _normalize_image(image_bytes: bytes) -> Optional[bytes]:
+    try:
+        with Image.open(BytesIO(image_bytes)) as img:
+            if img.mode != "RGB":
+                img = img.convert("RGB")
+            buffer = BytesIO()
+            img.save(buffer, format="JPEG", quality=90, optimize=True)
+            return buffer.getvalue()
+    except (UnidentifiedImageError, OSError):
+        return None
+
+
+def _generate_image_bytes(image_prompt: str) -> Optional[bytes]:
+    prompt = image_prompt or DEFAULT_IMAGE_PROMPT
+    raw_bytes: Optional[bytes] = None
+
+    try:
+        result = openai_client.images.generate(
+            model=IMAGE_MODEL,
+            prompt=prompt,
+            size="1792x1024",
+            quality="standard",
+        )
+        b64 = result.data[0].b64_json
+        if b64:
+            raw_bytes = base64.b64decode(b64)
+    except Exception as exc:  # noqa: BLE001
+        print("[POSTGEN] Ошибка генерации картинки:", exc)
+
+    if raw_bytes:
+        normalized = _normalize_image(raw_bytes)
+        if normalized:
+            return normalized
+
+    try:
+        with FALLBACK_IMAGE.open("rb") as backup:
+            fallback_bytes = backup.read()
+    except FileNotFoundError:
+        return raw_bytes
+
+    return _normalize_image(fallback_bytes) or fallback_bytes
+
+
+def _publish_post(message, caption: str, image_bytes: Optional[bytes]) -> None:
+    kb = types.InlineKeyboardMarkup()
+    kb.add(types.InlineKeyboardButton("Перейти к боту", url=BOT_LINK))
+
+    targets = [CHANNEL_ID, GROUP_ID]
+    try:
+        for target in targets:
+            if image_bytes:
+                buffer = BytesIO(image_bytes)
+                buffer.name = "syntera_post.jpg"
+                buffer.seek(0)
+                bot.send_photo(
+                    target,
+                    buffer,
+                    caption=caption,
+                    parse_mode="HTML",
+                    reply_markup=kb,
+                )
+            else:
+                bot.send_message(
+                    target,
+                    caption,
+                    parse_mode="HTML",
+                    reply_markup=kb,
+                )
+        bot.reply_to(message, "✅ Пост опубликован в канал и группу.")
+    except Exception as exc:  # noqa: BLE001
+        bot.reply_to(message, f"❌ Ошибка при публикации: {exc}")
+        traceback.print_exc()
+
+
+def _handle_post_request(message, mode: str) -> None:
+    user_id = getattr(message.from_user, "id", None)
+    if user_id != OWNER_ID:
+        bot.reply_to(message, "⛔ Команда доступна только владельцу.")
+        return
+
+    status_msg = bot.reply_to(message, "🧠 Генерирую контент, это займёт несколько секунд…")
+    caption = ""
+    image_prompt = ""
+
+    try:
+        if mode == "news":
+            text, image_prompt, headline = _generate_news_payload()
+            caption = f"<b>{headline}</b>\n\n{text}" if headline else text
+        else:
+            text, image_prompt = _generate_post_payload(mode)
+            caption = text
+
+        image_bytes = _generate_image_bytes(image_prompt)
+        _publish_post(message, caption, image_bytes)
+    except Exception as exc:  # noqa: BLE001
+        bot.reply_to(message, f"❌ Не удалось создать пост: {exc}")
+        traceback.print_exc()
+    finally:
+        with suppress(Exception):
+            bot.delete_message(status_msg.chat.id, status_msg.message_id)
+
+
+@bot.message_handler(commands=["post_short"])
+def create_short_post(message):
+    _handle_post_request(message, "short")
+
+
+@bot.message_handler(commands=["post_long"])
+def create_long_post(message):
+    _handle_post_request(message, "long")
+
+
+@bot.message_handler(commands=["post_news"])
+def create_news_post(message):
+    _handle_post_request(message, "news")
+
+
+__all__ = [
+    "create_short_post",
+    "create_long_post",
+    "create_news_post",
+]

--- a/bot.py
+++ b/bot.py
@@ -66,8 +66,8 @@ from openai_adapter import (
 )
 from text_utils import sanitize_for_telegram, sanitize_model_output
 
-# Регистрация команды /post
-import auto_post  # noqa: F401 - регистрация команды /post
+# Регистрация команд автопостинга
+import auto_post  # noqa: F401 - регистрация хендлеров автопостинга при импорте
 
 from usage_tracker import (
     compose_display_name,
@@ -86,7 +86,8 @@ def _register_bot_commands() -> None:
     """Отобразить основные команды в боковом меню Telegram."""
 
     owner_commands = [
-        types.BotCommand("post", "Создать пост"),
+        types.BotCommand("post_short", "Короткий пост"),
+        types.BotCommand("post_long", "Длинный пост"),
         types.BotCommand("post_news", "Новость с фото"),
         types.BotCommand("top_users", "Топ активных пользователей"),
         types.BotCommand("user_stats", "Статистика по ID"),
@@ -94,7 +95,12 @@ def _register_bot_commands() -> None:
 
     try:
         with suppress(Exception):
-            bot.delete_my_commands()
+            bot.delete_my_commands(scope=types.BotCommandScopeDefault())
+            default_menu_cls = getattr(types, "MenuButtonDefault", None)
+            if default_menu_cls:
+                bot.set_chat_menu_button(menu_button=default_menu_cls())
+            else:
+                bot.set_chat_menu_button()
         bot.set_my_commands(
             owner_commands,
             scope=types.BotCommandScopeChat(chat_id=OWNER_ID),

--- a/media.py
+++ b/media.py
@@ -22,6 +22,7 @@ def multimedia_menu():
         types.InlineKeyboardButton("Презентация", callback_data="mm_pptx"),
     )
     return kb
+
 # --- Точка входа из главного меню: команда «Медиа» ---
 
 def _display_name(user) -> str:
@@ -31,10 +32,6 @@ def _display_name(user) -> str:
         last_name=getattr(user, "last_name", None),
     )
 
-
-@bot.message_handler(func=lambda msg: msg.text == "Медиа")
-def open_multimedia(m):
-    bot.send_message(m.chat.id, "Выбери функцию:", reply_markup=multimedia_menu())
 
 # --- Ветки функций ---
 

--- a/settings.py
+++ b/settings.py
@@ -23,7 +23,7 @@ REDIS_DB = int(os.getenv("REDIS_DB", "0"))
 REDIS_PASSWORD = os.getenv("REDIS_PASSWORD") or None
 
 # --- Новые настройки моделей для мультимедиа ---
-IMAGE_MODEL = os.getenv("IMAGE_MODEL", "dall-e-3")        # генерация изображений (DALL·E 3 Standard)
+IMAGE_MODEL = os.getenv("IMAGE_MODEL", "gpt-image-1")     # генерация изображений (минимальная стоимость)
 VISION_MODEL = os.getenv("VISION_MODEL", "gpt-4o-mini")   # анализ изображений (vision)
 
 # --- Модель для основного чата (GPT-5 mini) ---

--- a/usage_tracker.py
+++ b/usage_tracker.py
@@ -433,26 +433,6 @@ def format_user_stats(user_id: int, display_hint: Optional[str] = None) -> str:
     return "\n".join(lines)
 
 
-__all__ = [
-    "compose_display_name",
-    "format_usage_report",
-    "format_user_stats",
-    "get_top_users",
-    "get_user_stats",
-    "init_usage_tracking",
-    "record_user_activity",
-]
-
-
-# --- Админские команды для владельца бота ---
-from settings import bot, OWNER_ID
-from telebot import types
-
-
-def _owner_only(user_id: Optional[int]) -> bool:
-    return user_id == OWNER_ID
-
-
 def format_usage_report(limit: int = 20) -> str:
     """Сводка по активности пользователей."""
     try:
@@ -482,53 +462,12 @@ def format_usage_report(limit: int = 20) -> str:
     return "\n\n".join(lines)
 
 
-@bot.message_handler(commands=["top_users"])
-def cmd_top_users(message):
-    """Команда доступна только владельцу: показывает топ пользователей."""
-    if not _owner_only(getattr(message.from_user, "id", None)):
-        bot.reply_to(message, "⛔ Команда доступна только владельцу бота.")
-        return
-
-    try:
-        report = format_usage_report()
-    except Exception as e:  # pragma: no cover - запасная защита
-        bot.send_message(message.chat.id, f"⚠️ Ошибка статистики: {e}")
-        return
-
-    bot.send_message(message.chat.id, report, parse_mode="HTML")
-
-
-@bot.message_handler(commands=["user_stats"])
-def cmd_user_stats(message):
-    """Показывает статистику по конкретному ID, только для владельца."""
-    if not _owner_only(getattr(message.from_user, "id", None)):
-        bot.reply_to(message, "⛔ Команда доступна только владельцу бота.")
-        return
-
-    parts = message.text.strip().split(maxsplit=1)
-    if len(parts) < 2:
-        bot.reply_to(message, "📎 Использование: /user_stats <user_id>")
-        return
-
-    try:
-        uid = int(parts[1])
-    except ValueError:
-        bot.reply_to(message, "⚠️ Некорректный ID.")
-        return
-
-    data = _load_user_record(uid)
-    if not data:
-        bot.reply_to(message, "❌ Данных по пользователю нет.")
-        return
-
-    text = (
-        f"<b>👤 Пользователь:</b> {data.get('username') or '—'}\n"
-        f"<b>ID:</b> <code>{uid}</code>\n\n"
-        f"Всего запросов: {data.get('total_requests', 0)}\n"
-        f"Текстовых: {data.get('text_requests', 0)}\n"
-        f"Изображений: {data.get('image_generations', 0)}\n"
-        f"Документов: {data.get('doc_generations', 0)}\n\n"
-        f"<b>Последняя активность:</b> "
-        f"{datetime.fromtimestamp(data.get('last_used_at', 0)).strftime('%d.%m.%Y %H:%M:%S')}"
-    )
-    bot.send_message(message.chat.id, text, parse_mode="HTML")
+__all__ = [
+    "compose_display_name",
+    "format_usage_report",
+    "format_user_stats",
+    "get_top_users",
+    "get_user_stats",
+    "init_usage_tracking",
+    "record_user_activity",
+]


### PR DESCRIPTION
## Summary
- rebuild the auto_post module to remove conflict markers, add /post_short and /post_long flows, and use GPT-Image-1 as the fallback image generator
- restrict slash commands to the owner while keeping the reply keyboard with four buttons for all users and ensure media handlers remain wired in
- streamline usage tracking helpers by removing duplicate bot handlers

## Testing
- python -m py_compile bot.py auto_post.py media.py usage_tracker.py settings.py storage.py openai_adapter.py bot_utils.py

------
https://chatgpt.com/codex/tasks/task_b_68e7fa365f1c832394e57b6484970a74