### PR TITLE
Fix vision chat payload for image analysis

### DIFF
--- a/media.py
+++ b/media.py
@@ -157,8 +157,8 @@ def on_photo_message(m):
             messages=[{
                 "role": "user",
                 "content": [
-                    {"type": "input_text", "text": "Опиши и проанализируй это фото кратко и по делу."},
-                    {"type": "input_image", "image_url": data_url}
+                    {"type": "text", "text": "Опиши и проанализируй это фото кратко и по делу."},
+                    {"type": "image_url", "image_url": {"url": data_url}},
                 ]
             }],
         )


### PR DESCRIPTION
## Summary
- update the vision chat completion payload to use the supported `text` and `image_url` content types
- wrap the encoded Telegram photo in the structure expected by the latest OpenAI API

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68ea3c38c1ec8323819c85fd2f10141f